### PR TITLE
Bug fix: allow using an AssumeRole ARN and a custom service endpoint

### DIFF
--- a/pkg/plugin/twinmaker/client.go
+++ b/pkg/plugin/twinmaker/client.go
@@ -47,16 +47,20 @@ func NewTwinMakerClient(settings models.TwinMakerDataSourceSetting) (TwinMakerCl
 	sessions := awsds.NewSessionCache()
 	agent := userAgentString("grafana-iot-twinmaker-app")
 
+	// Clients should not use a custom endpoint to load session credentials
+	noEndpointSettings := settings.AWSDatasourceSettings
+	noEndpointSettings.Endpoint = ""
+
 	// STS client can not use scoped down role to generate tokens
-	stssettings := settings.AWSDatasourceSettings
+	stssettings := noEndpointSettings
 	stssettings.AssumeRoleARN = ""
-	stssettings.Endpoint = "" // always standard
 
 	twinMakerService := func() (*iottwinmaker.IoTTwinMaker, error) {
-		sess, err := sessions.GetSession("", settings.AWSDatasourceSettings)
+		sess, err := sessions.GetSession("", noEndpointSettings)
 		if err != nil {
 			return nil, err
 		}
+		sess.Config.Endpoint = &settings.AWSDatasourceSettings.Endpoint
 
 		svc := iottwinmaker.New(sess, aws.NewConfig())
 		svc.Handlers.Send.PushFront(func(r *request.Request) {


### PR DESCRIPTION
Testers were not able to use the gamma TwinMaker service endpoint and specify an AssumeRoleArn. This was due to the GetSession() method in grafana-aws-sdk using the custom endpoint to call STS.AssumeRole for the TwinMaker client. To get around this we remove the Endpoint from the session settings, get the session credentials, then add the endpoint field back when instantiating the client.