### PR TITLE
More resilient check for valid externalId in externalIdProperty response

### DIFF
--- a/src/datasource/components/ConfigEditor.tsx
+++ b/src/datasource/components/ConfigEditor.tsx
@@ -67,7 +67,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
           <Alert title="Assume Role ARN" severity="error" style={{ width: 700 }}>
             Specify an IAM role to narrow the permission scope of this datasource. Follow the documentation{' '}
             <a
-              href="https://docs.aws.amazon.com/iot-twinmaker/latest/guide/datasource-integration.html"
+              href="https://docs.aws.amazon.com/iot-twinmaker/latest/guide/dashboard-IAM-role.html"
               target="_blank"
               rel="noreferrer noopener"
             >


### PR DESCRIPTION
1. Customers that use our samples to build their Lambdas will have an externalIdProperty in the History response of their alarms like the following:
```
externalIdProperty: {
  alarm_key: EXTERNAL_ID,
  propertyName: alarm_status
}
```
Will recommend customers to update their Lambdas and remove the `propertyName`, but in the meantime we will ignore properties that aren't in the property list or aren't externalIds.

2. Updated the URL in the alert pointing to our documentation on setting up the TwinMaker Dashboard Role