### PR TITLE
Enforce Assume Role ARN in GetToken calls

### DIFF
--- a/pkg/plugin/resource.go
+++ b/pkg/plugin/resource.go
@@ -19,6 +19,11 @@ func writeJsonResponse(w http.ResponseWriter, rsp interface{}, err error) {
 }
 
 func (ds *TwinMakerDatasource) HandleGetToken(w http.ResponseWriter, r *http.Request) {
+	if ds.settings.AssumeRoleARN == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message": "Assume Role ARN is missing in datasource configuration"}`))
+		return
+	}
 	token, err := ds.handler.GetSessionToken(r.Context(), time.Second*3600, ds.settings.WorkspaceID)
 	writeJsonResponse(w, token, err)
 }

--- a/pkg/plugin/resource.go
+++ b/pkg/plugin/resource.go
@@ -20,7 +20,7 @@ func writeJsonResponse(w http.ResponseWriter, rsp interface{}, err error) {
 
 func (ds *TwinMakerDatasource) HandleGetToken(w http.ResponseWriter, r *http.Request) {
 	if ds.settings.AssumeRoleARN == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(`{"message": "Assume Role ARN is missing in datasource configuration"}`))
 		return
 	}

--- a/pkg/plugin/twinmaker/client.go
+++ b/pkg/plugin/twinmaker/client.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/iottwinmaker"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -423,49 +422,9 @@ func (c *twinMakerClient) GetSessionToken(ctx context.Context, duration time.Dur
 		}
 
 		return out.Credentials, err
+	} else {
+		return nil, fmt.Errorf("assume role ARN is missing in datasource configuration")
 	}
-
-	// if there is a sessionToken set in the default credentials within
-	// the chain of authentication providers, it means they are temporary,
-	// and hence the frontend needs to use them directly and we don't
-	// need to call sts for temporary session tokens
-	creds, err := client.Config.Credentials.GetWithContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if creds.SessionToken != "" {
-		// force expire the creds here because of the expire window
-		// logic in the frontend, where it assumes the expiry before
-		// a certain time of the actual expiry
-		client.Config.Credentials.Expire()
-
-		creds, err := client.Config.Credentials.GetWithContext(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		// just force an expiry time here too since using the
-		// Credentials.ExpiresAt() is not supported for some
-		// Providers that might be being used
-		expiryTime := time.Now().Add(stscreds.DefaultDuration)
-
-		return &sts.Credentials{
-			AccessKeyId:     &creds.AccessKeyID,
-			SecretAccessKey: &creds.SecretAccessKey,
-			SessionToken:    &creds.SessionToken,
-			Expiration:      &expiryTime,
-		}, err
-	}
-
-	input := &sts.GetSessionTokenInput{
-		DurationSeconds: aws.Int64(int64(duration.Seconds())),
-	}
-	out, err := tokenService.GetSessionTokenWithContext(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-	return out.Credentials, err
 }
 
 // TODO, move to https://github.com/grafana/grafana-plugin-sdk-go

--- a/pkg/plugin/twinmaker/client_test.go
+++ b/pkg/plugin/twinmaker/client_test.go
@@ -35,7 +35,7 @@ func TestFetchAWSData(t *testing.T) {
 		require.NotEmpty(t, token)
 	})
 
-	t.Run("get a sts token with custom expiry when creds are temp", func(t *testing.T) {
+	t.Run("throw error when assume role arn is missing", func(t *testing.T) {
 		c, err := NewTwinMakerClient(models.TwinMakerDataSourceSetting{
 			// use credentials in ~/.aws/credentials
 			AWSDatasourceSettings: awsds.AWSDatasourceSettings{
@@ -48,10 +48,8 @@ func TestFetchAWSData(t *testing.T) {
 		require.NoError(t, err)
 
 		WorkspaceId := "GrafanaWorkspace"
-		token, err := c.GetSessionToken(context.Background(), time.Second*3600, WorkspaceId)
-		require.NoError(t, err)
-		require.NotEmpty(t, token)
-		require.NotNil(t, token.Expiration)
+		_, err = c.GetSessionToken(context.Background(), time.Second*3600, WorkspaceId)
+		require.Error(t, err)
 	})
 
 	t.Run("manually get an sts token when creds are permanent", func(t *testing.T) {


### PR DESCRIPTION
The frontend plugins that make AWS SDK calls on the browser get credentials from a 'token' backend resource call. This calls the functions GetSessionToken and HandleGetToken. Added logic to display an error whenever an Assume Role ARN is missing from the datasource configuration to ensure that the SceneViewer and VideoPlayer cannot be used to make calls with the authentication provider credentials directly.