### PR TITLE
Prevent panel refresh on data link clicks

### DIFF
--- a/src/common/variables.ts
+++ b/src/common/variables.ts
@@ -8,9 +8,10 @@ interface VariableOptions {
 export function getVariableOptions(opts?: VariableOptions) {
   const templateSrv = getTemplateSrv();
   return templateSrv.getVariables().map((t) => {
-    const value = '${' + t.name + '}';
+    const value = t.name;
+    const label = '${' + t.name + '}';
     const info: SelectableValue<string> = {
-      label: opts?.hideValue ? `${value}` : `${value} = ${templateSrv.replace(value)}`,
+      label: opts?.hideValue ? `${label}` : `${label} = ${templateSrv.replace(label)}`,
       value,
       icon: 'arrow-right', // not sure what makes the most sense
     };

--- a/src/datasource/dashboards/twinmaker-alarm-dashboard.json
+++ b/src/datasource/dashboards/twinmaker-alarm-dashboard.json
@@ -117,11 +117,11 @@
             "vars": [
               {
                 "fieldName": "entityId",
-                "name": "${sel_entity}"
+                "name": "sel_entity"
               },
               {
                 "fieldName": "alarmName",
-                "name": "${sel_comp}"
+                "name": "sel_comp"
               }
             ]
           }
@@ -221,8 +221,8 @@
       },
       "id": 6,
       "options": {
-        "customSelCompVarName": "${sel_comp}",
-        "customSelEntityVarName": "${sel_entity}",
+        "customSelCompVarName": "sel_comp",
+        "customSelEntityVarName": "sel_entity",
         "datasource": "${DS_AWS_IOT TWINMAKER}",
         "sceneId": ""
       },

--- a/src/datasource/dashboards/twinmaker-main-dashboard.json
+++ b/src/datasource/dashboards/twinmaker-main-dashboard.json
@@ -211,11 +211,11 @@
             "vars": [
               {
                 "fieldName": "entityId",
-                "name": "${sel_entity}"
+                "name": "sel_entity"
               },
               {
                 "fieldName": "alarmName",
-                "name": "${sel_comp}"
+                "name": "sel_comp"
               }
             ]
           }
@@ -284,8 +284,8 @@
       },
       "id": 6,
       "options": {
-        "customSelCompVarName": "${sel_comp}",
-        "customSelEntityVarName": "${sel_entity}",
+        "customSelCompVarName": "sel_comp",
+        "customSelEntityVarName": "sel_entity",
         "datasource": "${DS_AWS_IOT TWINMAKER}",
         "sceneId": ""
       },


### PR DESCRIPTION
Dependent on https://github.com/grafana/grafana/pull/51003. Fixes https://github.com/grafana/grafana-iot-twinmaker-app/issues/67

Before:

![url-panel-update-before](https://user-images.githubusercontent.com/360020/174302129-855f661c-ae60-4122-94d9-a34b43f15a2f.gif)

After:

![url-panel-update-after](https://user-images.githubusercontent.com/360020/174302161-9f3d4767-a255-47b5-8ecf-cbf3c3957ab5.gif)