### PR TITLE
Reverting changes for preventing panel refresh on data link clicks

### DIFF
--- a/src/common/variables.ts
+++ b/src/common/variables.ts
@@ -8,10 +8,9 @@ interface VariableOptions {
 export function getVariableOptions(opts?: VariableOptions) {
   const templateSrv = getTemplateSrv();
   return templateSrv.getVariables().map((t) => {
-    const value = t.name;
-    const label = '${' + t.name + '}';
+    const value = '${' + t.name + '}';
     const info: SelectableValue<string> = {
-      label: opts?.hideValue ? `${label}` : `${label} = ${templateSrv.replace(label)}`,
+      label: opts?.hideValue ? `${value}` : `${value} = ${templateSrv.replace(value)}`,
       value,
       icon: 'arrow-right', // not sure what makes the most sense
     };

--- a/src/datasource/dashboards/twinmaker-alarm-dashboard.json
+++ b/src/datasource/dashboards/twinmaker-alarm-dashboard.json
@@ -117,11 +117,11 @@
             "vars": [
               {
                 "fieldName": "entityId",
-                "name": "sel_entity"
+                "name": "${sel_entity}"
               },
               {
                 "fieldName": "alarmName",
-                "name": "sel_comp"
+                "name": "${sel_comp}"
               }
             ]
           }
@@ -221,8 +221,8 @@
       },
       "id": 6,
       "options": {
-        "customSelCompVarName": "sel_comp",
-        "customSelEntityVarName": "sel_entity",
+        "customSelCompVarName": "${sel_comp}",
+        "customSelEntityVarName": "${sel_entity}",
         "datasource": "${DS_AWS_IOT TWINMAKER}",
         "sceneId": ""
       },

--- a/src/datasource/dashboards/twinmaker-main-dashboard.json
+++ b/src/datasource/dashboards/twinmaker-main-dashboard.json
@@ -211,11 +211,11 @@
             "vars": [
               {
                 "fieldName": "entityId",
-                "name": "sel_entity"
+                "name": "${sel_entity}"
               },
               {
                 "fieldName": "alarmName",
-                "name": "sel_comp"
+                "name": "${sel_comp}"
               }
             ]
           }
@@ -284,8 +284,8 @@
       },
       "id": 6,
       "options": {
-        "customSelCompVarName": "sel_comp",
-        "customSelEntityVarName": "sel_entity",
+        "customSelCompVarName": "${sel_comp}",
+        "customSelEntityVarName": "${sel_entity}",
         "datasource": "${DS_AWS_IOT TWINMAKER}",
         "sceneId": ""
       },


### PR DESCRIPTION
Bugs:
* Scene Viewer - clicking on a tag does not move the camera to face it
* Query editor - cannot use any template variables in the query editor. The "value" does not have `$` so the temp var name is treated as a TwinMaker ID/name

Need to investigate fixing these issues before moving forward with the panel refresh change.