### PR TITLE
Data source: Prevent editor error in explore

### DIFF
--- a/src/common/dashboard.ts
+++ b/src/common/dashboard.ts
@@ -25,10 +25,10 @@ export interface Dashboard extends DashboardJSON {
 /**
  * Get access to the current dashboard
  */
-export function getCurrentDashboard() {
+export function getCurrentDashboard(): Dashboard | undefined {
   const $injector = getLegacyAngularInjector();
   const dashboardSrv = $injector.get('dashboardSrv');
-  return dashboardSrv.dashboard as Dashboard;
+  return dashboardSrv.dashboard;
 }
 
 export function getDashboardByUid(uid: string): Promise<DashboardMeta> {

--- a/src/common/managerSimple.ts
+++ b/src/common/managerSimple.ts
@@ -17,6 +17,10 @@ export class SimpleTwinMakerDashboardManager implements TwinMakerDashboardManage
   listTwinMakerPanels() {
     const keep = new Set(Object.values(TWINMAKER_PANEL_TYPE_ID));
     const dash = getCurrentDashboard();
+    // dashboard is not available in explore view
+    if (!dash) {
+      return [];
+    }
     return dash.panels
       .filter((p) => keep.has(p.type))
       .map((p) => {
@@ -34,7 +38,7 @@ export class SimpleTwinMakerDashboardManager implements TwinMakerDashboardManage
 
   refresh(panelId?: number) {
     console.log('refresh all panels pointing to: ', panelId);
-    getCurrentDashboard().panels.forEach((p) => {
+    getCurrentDashboard()?.panels.forEach((p) => {
       if (p.targets) {
         for (const q of p.targets) {
           if (isTwinMakerPanelQuery(q) && (q.panelId === panelId || !panelId)) {
@@ -75,7 +79,7 @@ export class SimpleTwinMakerDashboardManager implements TwinMakerDashboardManage
       return panelTopicInfo;
     }
     // ??? some panels may have different support
-    const panel = getCurrentDashboard().panels.find((p) => p.id === panelId);
+    const panel = getCurrentDashboard()?.panels.find((p) => p.id === panelId);
     if (panel?.type === TWINMAKER_PANEL_TYPE_ID.LAYOUT) {
       return panelTopicInfo;
     }

--- a/src/panels/layout/LayoutPanel.tsx
+++ b/src/panels/layout/LayoutPanel.tsx
@@ -46,7 +46,7 @@ export class LayoutPanel extends Component<Props, State> {
   ds?: TwinMakerDataSource;
   loading?: boolean;
   initalized?: boolean;
-  dashboardUid: string;
+  dashboardUid: string | undefined;
   error?: string;
 
   constructor(props: Props) {
@@ -61,14 +61,16 @@ export class LayoutPanel extends Component<Props, State> {
     };
 
     const dashboard = getCurrentDashboard();
-    this.dashboardUid = dashboard.uid;
-    for (const panel of dashboard.panels) {
-      if (panel.id !== this.props.id && panel.type === TWINMAKER_PANEL_TYPE_ID.LAYOUT) {
-        const isEditor = window.location.href.includes('editPanel');
-        if (!isEditor) {
-          this.error = 'Only one layout panel allowed in a dashboard';
+    if (dashboard) {
+      this.dashboardUid = dashboard.uid;
+      for (const panel of dashboard.panels) {
+        if (panel.id !== this.props.id && panel.type === TWINMAKER_PANEL_TYPE_ID.LAYOUT) {
+          const isEditor = window.location.href.includes('editPanel');
+          if (!isEditor) {
+            this.error = 'Only one layout panel allowed in a dashboard';
+          }
+          break;
         }
-        break;
       }
     }
 

--- a/src/panels/layout/merge.ts
+++ b/src/panels/layout/merge.ts
@@ -14,10 +14,10 @@ export async function mergeDashboard(eventBus: EventBus, targetDashboardId: stri
   const currentDashboard = getCurrentDashboard();
 
   console.log('PREPARE: ', targetDashboardId, dashboard.panels);
-  const panels = prepareDashboardMerge(eventBus, currentDashboard.panels, dashboard.panels);
+  const panels = prepareDashboardMerge(eventBus, currentDashboard?.panels ?? [], dashboard.panels);
   if (panels.length) {
     console.log('UPDATE: ', panels);
-    const info = currentDashboard.updatePanels(panels);
+    const info = currentDashboard?.updatePanels(panels);
     console.log('MERGED: ', info);
     return true;
   }

--- a/src/panels/scene-viewer/helpers.ts
+++ b/src/panels/scene-viewer/helpers.ts
@@ -14,9 +14,9 @@ export function mergeDashboard(targetDashboardId?: string): Promise<PanelOptions
     const dashboard = meta.dashboard;
     const currentDashboard = getCurrentDashboard();
 
-    const currentViewerOptions = updateSceneViewerPanel(currentDashboard.panels, dashboard.panels);
+    const currentViewerOptions = updateSceneViewerPanel(currentDashboard?.panels ?? [], dashboard.panels);
 
-    const info = currentDashboard.updatePanels(dashboard.panels);
+    const info = currentDashboard?.updatePanels(dashboard.panels);
     console.log('LOAD', info);
     return currentViewerOptions;
   });


### PR DESCRIPTION
### Why

Refreshing the page in explore causes this error in the query editor:

<img width="825" alt="image" src="https://user-images.githubusercontent.com/360020/181786451-ed43a919-8690-4c1d-9005-9c7f940b4c4a.png">

### What

The query editor was attempting to access the current dashboard, which doesn't exist in explore. This change prevents an empty result from throwing an exception.