### PR TITLE
extend alarm list to support basic and sitewise alarm extensions

### DIFF
--- a/pkg/plugin/twinmaker/handler.go
+++ b/pkg/plugin/twinmaker/handler.go
@@ -428,6 +428,7 @@ func (s *twinMakerHandler) GetEntityHistory(ctx context.Context, query models.Tw
 func (s *twinMakerHandler) GetAlarms(ctx context.Context, query models.TwinMakerQuery) (dr backend.DataResponse) {
 	failures := []data.Notice{}
 	alarmComponentType := "com.amazon.iottwinmaker.alarm.basic"
+	sitewiseAlarmComponentType := "com.amazon.iotsitewise.alarm"
 	externalIdKey := "alarm_key"
 	alarmProperty := "alarm_status"
 	isFiltered := len(query.PropertyFilter) > 0
@@ -446,20 +447,35 @@ func (s *twinMakerHandler) GetAlarms(ctx context.Context, query models.TwinMaker
 
 	// Get all componentTypes that extend from the base alarm type
 	query.ComponentTypeId = alarmComponentType
-	componentTypes, err := s.client.ListComponentTypes(ctx, query)
+	basicComponentTypes, err := s.client.ListComponentTypes(ctx, query)
 	dr.Error = err
 	if err != nil {
 		return
 	}
-	if componentTypes == nil {
+	if basicComponentTypes == nil {
 		dr.Error = fmt.Errorf("error loading componentTypes for GetAlarms query")
 		return
 	}
 
+	// Get all componentTypes that extend from the sitewise alarm type
+	// list-component-types only support direct child extend checks currently
+	query.ComponentTypeId = sitewiseAlarmComponentType
+	sitewiseComponentTypes, err := s.client.ListComponentTypes(ctx, query)
+	dr.Error = err
+	if err != nil {
+		return
+	}
+	if sitewiseComponentTypes == nil {
+		dr.Error = fmt.Errorf("error loading componentTypes for GetAlarms query")
+		return
+	}
+	componentTypeSummaryResults := basicComponentTypes.ComponentTypeSummaries
+	componentTypeSummaryResults = append(componentTypeSummaryResults, sitewiseComponentTypes.ComponentTypeSummaries...)
+
 	// Get the propertyValueHistory associated with all componentTypes from above
 	var pValues []PropertyReference
 
-	for _, componentTypeSummary := range componentTypes.ComponentTypeSummaries {
+	for _, componentTypeSummary := range componentTypeSummaryResults {
 		// Set mapping of alarm component types for quick lookup later
 		query.EntityId = ""
 		query.Properties = []*string{aws.String(alarmProperty)}
@@ -477,11 +493,11 @@ func (s *twinMakerHandler) GetAlarms(ctx context.Context, query models.TwinMaker
 		failures = append(failures, newFailures...)
 		pValues = append(pValues, propertyReferences...)
 		if isLimited {
-		    // update the queries' maxResults so we ask for less on the next iteration
-		    query.MaxResults = maxNoOfAlarms - len(pValues)
-            if len(pValues) >= maxNoOfAlarms {
-                break
-            }
+			// update the queries' maxResults so we ask for less on the next iteration
+			query.MaxResults = maxNoOfAlarms - len(pValues)
+			if len(pValues) >= maxNoOfAlarms {
+				break
+			}
 		}
 	}
 

--- a/pkg/plugin/twinmaker/utils.go
+++ b/pkg/plugin/twinmaker/utils.go
@@ -176,70 +176,70 @@ func GetEntityPropertyReferenceKey(entityPropertyReference *iottwinmaker.EntityP
 /*
 * This function returns the latest value for each entity property.
 * Assumes that the Roci Api query returns data from latest to oldest.
-*/
+ */
 func (s *twinMakerHandler) GetLatestPropertyValueHistoryPaginated(ctx context.Context, query models.TwinMakerQuery, propertyDefinitions map[string]*iottwinmaker.PropertyDefinitionResponse) (*iottwinmaker.GetPropertyValueHistoryOutput, error) {
-        var maxPropertyValues int
-        isLimited := false
-        if query.MaxResults > 0 {
-            isLimited = true
-            maxPropertyValues = query.MaxResults
-            query.MaxResults = 0
-        }
+	var maxPropertyValues int
+	isLimited := false
+	if query.MaxResults > 0 {
+		isLimited = true
+		maxPropertyValues = query.MaxResults
+		query.MaxResults = 0
+	}
 
-        propertyValueHistories, err := s.client.GetPropertyValueHistory(ctx, query)
-        if err != nil {
-            return nil, err
-        }
+	propertyValueHistories, err := s.client.GetPropertyValueHistory(ctx, query)
+	if err != nil {
+		return nil, err
+	}
 
-        // Keep mapping of entityPropertyReferences to its index in the result's propertyValues
-        entityPropertyReferenceMapping := map[string]int{}
-        for i, propertyValue := range propertyValueHistories.PropertyValues {
-            refKey := GetEntityPropertyReferenceKey(propertyValue.EntityPropertyReference, propertyDefinitions)
-            entityPropertyReferenceMapping[refKey] = i
-		    values := propertyValueHistories.PropertyValues[i].Values
-            // only save 1 value
-            if len(values) > 0 {
-                propertyValueHistories.PropertyValues[i].Values = values[0:1]
-            }
-            // if we have max results, return
-            if isLimited && len(entityPropertyReferenceMapping) >= maxPropertyValues {
-                if len(propertyValueHistories.PropertyValues) > maxPropertyValues {
-                    propertyValueHistories.PropertyValues = propertyValueHistories.PropertyValues[:maxPropertyValues]
-                }
-                return propertyValueHistories, nil
-            }
-        }
+	// Keep mapping of entityPropertyReferences to its index in the result's propertyValues
+	entityPropertyReferenceMapping := map[string]int{}
+	for i, propertyValue := range propertyValueHistories.PropertyValues {
+		refKey := GetEntityPropertyReferenceKey(propertyValue.EntityPropertyReference, propertyDefinitions)
+		entityPropertyReferenceMapping[refKey] = i
+		values := propertyValueHistories.PropertyValues[i].Values
+		// only save 1 value
+		if len(values) > 0 {
+			propertyValueHistories.PropertyValues[i].Values = values[0:1]
+		}
+		// if we have max results, return
+		if isLimited && len(entityPropertyReferenceMapping) >= maxPropertyValues {
+			if len(propertyValueHistories.PropertyValues) > maxPropertyValues {
+				propertyValueHistories.PropertyValues = propertyValueHistories.PropertyValues[:maxPropertyValues]
+			}
+			return propertyValueHistories, nil
+		}
+	}
 
-        cPropertyValuesHistories := propertyValueHistories
-        for cPropertyValuesHistories.NextToken != nil {
-            query.NextToken = *cPropertyValuesHistories.NextToken
-            cPropertyValuesHistories, err := s.client.GetPropertyValueHistory(ctx, query)
-            if err != nil {
-                return nil, err
-            }
+	cPropertyValuesHistories := propertyValueHistories
+	for cPropertyValuesHistories.NextToken != nil {
+		query.NextToken = *cPropertyValuesHistories.NextToken
+		cPropertyValuesHistories, err := s.client.GetPropertyValueHistory(ctx, query)
+		if err != nil {
+			return nil, err
+		}
 
-            for _, propertyValue := range cPropertyValuesHistories.PropertyValues {
-                refKey := GetEntityPropertyReferenceKey(propertyValue.EntityPropertyReference, propertyDefinitions)
-                if _, ok := entityPropertyReferenceMapping[refKey]; !ok {
-                    entityPropertyReferenceMapping[refKey] = len(propertyValueHistories.PropertyValues)
-                    // only save 1 value
-                    if len(propertyValue.Values) > 0 {
-                        propertyValue.Values = propertyValue.Values[0:1]
-                    }
-                    propertyValueHistories.PropertyValues = append(propertyValueHistories.PropertyValues, propertyValue)
+		for _, propertyValue := range cPropertyValuesHistories.PropertyValues {
+			refKey := GetEntityPropertyReferenceKey(propertyValue.EntityPropertyReference, propertyDefinitions)
+			if _, ok := entityPropertyReferenceMapping[refKey]; !ok {
+				entityPropertyReferenceMapping[refKey] = len(propertyValueHistories.PropertyValues)
+				// only save 1 value
+				if len(propertyValue.Values) > 0 {
+					propertyValue.Values = propertyValue.Values[0:1]
+				}
+				propertyValueHistories.PropertyValues = append(propertyValueHistories.PropertyValues, propertyValue)
 
-                    // if we have max results, return
-                    if isLimited && len(entityPropertyReferenceMapping) >= maxPropertyValues {
-                        return propertyValueHistories, nil
-                    }
-                }
-            }
+				// if we have max results, return
+				if isLimited && len(entityPropertyReferenceMapping) >= maxPropertyValues {
+					return propertyValueHistories, nil
+				}
+			}
+		}
 
-            propertyValueHistories.NextToken = cPropertyValuesHistories.NextToken
-        }
+		propertyValueHistories.NextToken = cPropertyValuesHistories.NextToken
+	}
 
-        return propertyValueHistories, nil
-     }
+	return propertyValueHistories, nil
+}
 
 func (s *twinMakerHandler) GetPropertyValueHistoryPaginated(ctx context.Context, query models.TwinMakerQuery, propertyDefinitions map[string]*iottwinmaker.PropertyDefinitionResponse) (*iottwinmaker.GetPropertyValueHistoryOutput, error) {
 	propertyValueHistories, err := s.client.GetPropertyValueHistory(ctx, query)
@@ -361,7 +361,6 @@ func (s *twinMakerHandler) GetComponentHistoryWithLookupHelper(ctx context.Conte
 								}
 							}
 						}
-						break
 					}
 				}
 
@@ -384,11 +383,11 @@ func (s *twinMakerHandler) GetComponentHistoryWithLookupHelper(ctx context.Conte
 }
 
 func (s *twinMakerHandler) GetLatestComponentHistoryWithLookup(ctx context.Context, query models.TwinMakerQuery) (p []PropertyReference, n []data.Notice, err error) {
-    return s.GetComponentHistoryWithLookupHelper(ctx, query, s.GetLatestPropertyValueHistoryPaginated)
+	return s.GetComponentHistoryWithLookupHelper(ctx, query, s.GetLatestPropertyValueHistoryPaginated)
 }
 
 func (s *twinMakerHandler) GetComponentHistoryWithLookup(ctx context.Context, query models.TwinMakerQuery) (p []PropertyReference, n []data.Notice, err error) {
-    return s.GetComponentHistoryWithLookupHelper(ctx, query, s.GetPropertyValueHistoryPaginated)
+	return s.GetComponentHistoryWithLookupHelper(ctx, query, s.GetPropertyValueHistoryPaginated)
 }
 
 func getTimeObjectFromStringTime(timeString *string) (*time.Time, error) {


### PR DESCRIPTION
We PR 84 for how to test alarm configuration (https://github.com/grafana/grafana-iot-twinmaker-app/pull/84).  

Current TwinMaker API only allows for direct child to be search for by list-component-types API when using the extendsFrom.  Thus to enable finding extensions of both the basic alarm and the new sitewise 1p alarm we need to do two queries even though the sitewise 1P alarm component type is extended from the twinmaker basic alarm component type.

This was testing using entities that have 2 alarms of the same componentType on the same entity which exposed an issue with an extra 'break' in the utils.go that caused the search to exit on the first matching componentType even if the externalId didn't match.