### PR TITLE
DataSource: Add frontend request looper fallback

### DIFF
--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -55,6 +55,7 @@ func (f *TwinMakerPropertyFilter) ToTwinMakerFilter() *iottwinmaker.PropertyFilt
 
 // TwinMakerQuery model
 type TwinMakerQuery struct {
+	GrafanaLiveEnabled bool                          `json:"grafanaLiveEnabled,omitempty"`
 	IsStreaming        bool                          `json:"isStreaming,omitempty"`
 	WorkspaceId        string                        `json:"workspaceId,omitempty"`
 	EntityId           string                        `json:"entityId,omitempty"`

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -129,9 +129,9 @@ func (ds *TwinMakerDatasource) QueryData(ctx context.Context, req *backend.Query
 			query.NextToken = customMeta.NextToken
 		}
 
-		// we don't need to continue if the query is not a stream
+		// we don't need to continue if Live is disabled, the query is not streaming updates,
 		// or if the result is empty.
-		if (query.NextToken == "" && !query.IsStreaming) || len(res.Frames) == 0 {
+		if !query.GrafanaLiveEnabled || (query.NextToken == "" && !query.IsStreaming) || len(res.Frames) == 0 {
 			response.Responses[q.RefID] = res
 			continue
 		}

--- a/src/common/manager.ts
+++ b/src/common/manager.ts
@@ -46,6 +46,7 @@ export interface TwinMakerQuery extends DataQuery {
   filter?: TwinMakerPropertyFilter[];
   maxResults?: number;
   order?: TwinMakerResultOrder;
+  grafanaLiveEnabled: boolean;
   isStreaming?: boolean;
   intervalStreaming?: string;
 }

--- a/src/datasource/components/QueryEditor.tsx
+++ b/src/datasource/components/QueryEditor.tsx
@@ -36,11 +36,10 @@ import {
   TwinMakerPropertyFilter,
   DEFAULT_PROPERTY_FILTER_OPERATOR,
 } from 'common/manager';
-import { getTemplateSrv, getGrafanaLiveSrv } from '@grafana/runtime';
+import { getTemplateSrv } from '@grafana/runtime';
 import { getVariableOptions } from 'common/variables';
 import FilterQueryEditor from './FilterQueryEditor';
 import { BlurTextInput } from './BlurTextInput';
-import { Subscription } from 'rxjs';
 
 export const firstLabelWidth = 18;
 
@@ -58,7 +57,6 @@ interface State {
 
 export class QueryEditor extends PureComponent<Props, State> {
   panels: Array<SelectableValue<number>>;
-  subs: Subscription | undefined;
 
   constructor(props: Props) {
     super(props);
@@ -73,19 +71,6 @@ export class QueryEditor extends PureComponent<Props, State> {
     this.loadEntityInfo(this.props.query);
     this.loadTopicInfo(this.props.query);
     this.setState({ templateVars: getVariableOptions({ keepVarSyntax: true }) });
-    this.subs = getGrafanaLiveSrv()
-      .getConnectionState()
-      .subscribe({
-        next: (v) => {
-          this.setState({ hasStreaming: v });
-        },
-      });
-  }
-
-  componentWillUnmount() {
-    if (this.subs) {
-      this.subs.unsubscribe();
-    }
   }
 
   loadWorkspaceInfo = async () => {
@@ -407,7 +392,7 @@ export class QueryEditor extends PureComponent<Props, State> {
   }
 
   renderStreamingInputs(query: TwinMakerQuery) {
-    if (!this.state.hasStreaming) {
+    if (!this.props.datasource.grafanaLiveEnabled) {
       return null;
     }
 

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -1,23 +1,36 @@
-import { Observable } from 'rxjs';
-import { DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
-import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
+import { Observable, Subscription } from 'rxjs';
+import { DataFrame, DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
+import { DataSourceWithBackend, getGrafanaLiveSrv, getTemplateSrv } from '@grafana/runtime';
 
-import { TwinMakerDataSourceOptions, AWSTokenInfo } from './types';
+import { TwinMakerDataSourceOptions, AWSTokenInfo, TwinMakerCustomMeta } from './types';
 import { Credentials } from 'aws-sdk/global';
 import { TwinMakerWorkspaceInfoSupplier } from 'common/info/types';
 import { getCachingWorkspaceInfoSupplier, getTwinMakerWorkspaceInfoSupplier } from 'common/info/info';
 import { TwinMakerQueryType, TwinMakerQuery } from 'common/manager';
 import { Credentials as CredentialsV3, CredentialProvider } from '@aws-sdk/types';
+import { getRequestLooper, MultiRequestTracker } from './requestLooper';
+import { appendMatchingFrames } from './appendFrames';
 
 export class TwinMakerDataSource extends DataSourceWithBackend<TwinMakerQuery, TwinMakerDataSourceOptions> {
+  public grafanaLiveEnabled: boolean;
   private workspaceId: string;
+  private liveConnectionSubscription: Subscription;
   readonly info: TwinMakerWorkspaceInfoSupplier;
 
   constructor(public instanceSettings: DataSourceInstanceSettings<TwinMakerDataSourceOptions>) {
     super(instanceSettings);
 
     this.workspaceId = instanceSettings.jsonData.workspaceId!;
-
+    this.grafanaLiveEnabled = true;
+    
+    this.liveConnectionSubscription = getGrafanaLiveSrv()
+      .getConnectionState()
+      .subscribe({
+        next: (v) => {
+          this.grafanaLiveEnabled = v;
+        },
+      })
+  
     // Load workspace info from resource calls
     this.info = getCachingWorkspaceInfoSupplier(
       getTwinMakerWorkspaceInfoSupplier((p, params) => {
@@ -67,9 +80,65 @@ export class TwinMakerDataSource extends DataSourceWithBackend<TwinMakerQuery, T
     };
   }
 
-  query(request: DataQueryRequest<TwinMakerQuery>): Observable<DataQueryResponse> {
-    return super.query(request);
+  query(options: DataQueryRequest<TwinMakerQuery>): Observable<DataQueryResponse> {
+    options.targets = options.targets.map((t) => ({...t, grafanaLiveEnabled: this.grafanaLiveEnabled})); 
+    if (this.grafanaLiveEnabled) {
+      return super.query(options);
+    } 
+
+    return getRequestLooper(options, {
+      // Check for a "nextToken" in the response
+      getNextQueries: (rsp: DataQueryResponse) => {
+        if (rsp.data?.length) {
+          const used = new Set<string>();
+          const next: TwinMakerQuery[] = [];
+          for (const frame of rsp.data as DataFrame[]) {
+            const meta = frame.meta?.custom as TwinMakerCustomMeta;
+            if (meta && meta.nextToken && !used.has(meta.nextToken)) {
+              const query = options.targets.find((t) => t.refId === frame.refId);
+              if (query) {
+                used.add(meta.nextToken);
+                next.push({
+                  ...query,
+                  nextToken: meta.nextToken,
+                });
+              }
+            }
+          }
+          if (next.length) {
+            return next;
+          }
+        }
+        return undefined;
+      },
+
+      /**
+       * The original request
+       */
+      query: (request: DataQueryRequest<TwinMakerQuery>) => {
+        return super.query(request);
+      },
+
+      /**
+       * Process the results
+       */
+      process: (t: MultiRequestTracker, data: DataFrame[], isLast: boolean) => {
+        if (t.data) {
+          // append rows to fields with the same structure
+          t.data = appendMatchingFrames(t.data, data);
+        } else {
+          t.data = data; // hang on to the results from the last query
+        }
+        return t.data;
+      },
+
+      /**
+       * Callback that gets executed when unsubscribed
+       */
+      onCancel: (tracker: MultiRequestTracker) => {},
+    });
   }
+
 
   // Fetch temporary AWS tokens from the backend plugin and convert them into JS SDK Credentials
   getTokens = async (): Promise<Credentials> => {

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -12,9 +12,8 @@ import { getRequestLooper, MultiRequestTracker } from './requestLooper';
 import { appendMatchingFrames } from './appendFrames';
 
 export class TwinMakerDataSource extends DataSourceWithBackend<TwinMakerQuery, TwinMakerDataSourceOptions> {
-  public grafanaLiveEnabled: boolean;
+  grafanaLiveEnabled: boolean;
   private workspaceId: string;
-  private liveConnectionSubscription: Subscription;
   readonly info: TwinMakerWorkspaceInfoSupplier;
 
   constructor(public instanceSettings: DataSourceInstanceSettings<TwinMakerDataSourceOptions>) {
@@ -22,15 +21,15 @@ export class TwinMakerDataSource extends DataSourceWithBackend<TwinMakerQuery, T
 
     this.workspaceId = instanceSettings.jsonData.workspaceId!;
     this.grafanaLiveEnabled = true;
-    
-    this.liveConnectionSubscription = getGrafanaLiveSrv()
+
+    getGrafanaLiveSrv()
       .getConnectionState()
       .subscribe({
         next: (v) => {
           this.grafanaLiveEnabled = v;
         },
-      })
-  
+      });
+
     // Load workspace info from resource calls
     this.info = getCachingWorkspaceInfoSupplier(
       getTwinMakerWorkspaceInfoSupplier((p, params) => {
@@ -81,10 +80,10 @@ export class TwinMakerDataSource extends DataSourceWithBackend<TwinMakerQuery, T
   }
 
   query(options: DataQueryRequest<TwinMakerQuery>): Observable<DataQueryResponse> {
-    options.targets = options.targets.map((t) => ({...t, grafanaLiveEnabled: this.grafanaLiveEnabled})); 
+    options.targets = options.targets.map((t) => ({ ...t, grafanaLiveEnabled: this.grafanaLiveEnabled }));
     if (this.grafanaLiveEnabled) {
       return super.query(options);
-    } 
+    }
 
     return getRequestLooper(options, {
       // Check for a "nextToken" in the response
@@ -138,7 +137,6 @@ export class TwinMakerDataSource extends DataSourceWithBackend<TwinMakerQuery, T
       onCancel: (tracker: MultiRequestTracker) => {},
     });
   }
-
 
   // Fetch temporary AWS tokens from the backend plugin and convert them into JS SDK Credentials
   getTokens = async (): Promise<Credentials> => {

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -1,4 +1,4 @@
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 import { DataFrame, DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
 import { DataSourceWithBackend, getGrafanaLiveSrv, getTemplateSrv } from '@grafana/runtime';
 

--- a/src/datasource/requestLooper.ts
+++ b/src/datasource/requestLooper.ts
@@ -1,0 +1,99 @@
+import { DataQuery, DataQueryRequest, DataQueryResponse, LoadingState, DataFrame } from '@grafana/data';
+import { Observable, Subscription } from 'rxjs';
+
+export interface MultiRequestTracker {
+  fetchStartTime?: number; // The frontend clock
+  fetchEndTime?: number; // The frontend clock
+  data?: DataFrame[];
+}
+
+export interface RequestLoopOptions<TQuery extends DataQuery = DataQuery> {
+  /**
+   * If the response needs an additional request to execute, return it here
+   */
+  getNextQueries: (rsp: DataQueryResponse) => TQuery[] | undefined;
+
+  /**
+   * The datasource execute method
+   */
+  query: (req: DataQueryRequest<TQuery>) => Observable<DataQueryResponse>;
+
+  /**
+   * Process the results
+   */
+  process: (tracker: MultiRequestTracker, data: DataFrame[], isLast: boolean) => DataFrame[];
+
+  /**
+   * Callback that gets executed when unsubscribed
+   */
+  onCancel: (tracker: MultiRequestTracker) => void;
+}
+
+/**
+ * Continue executing requests as long as `getNextQuery` returns a query
+ */
+export function getRequestLooper<T extends DataQuery = DataQuery>(
+  req: DataQueryRequest<T>,
+  options: RequestLoopOptions<T>
+): Observable<DataQueryResponse> {
+  return new Observable<DataQueryResponse>((subscriber) => {
+    let nextQueries: T[] | undefined = undefined;
+    let subscription: Subscription | undefined = undefined;
+    const tracker: MultiRequestTracker = {
+      fetchStartTime: Date.now(),
+      fetchEndTime: undefined,
+    };
+    let loadingState: LoadingState | undefined = LoadingState.Loading;
+    let count = 1;
+
+    // Single observer gets reused for each request
+    const observer = {
+      next: (rsp: DataQueryResponse) => {
+        tracker.fetchEndTime = Date.now();
+        loadingState = rsp.state;
+        if (loadingState !== LoadingState.Error) {
+          nextQueries = options.getNextQueries(rsp);
+        }
+        const data = options.process(tracker, rsp.data, !!!nextQueries);
+        subscriber.next({ ...rsp, data, state: loadingState, key: req.requestId });
+      },
+      error: (err: any) => {
+        subscriber.error(err);
+      },
+      complete: () => {
+        if (subscription) {
+          subscription.unsubscribe();
+          subscription = undefined;
+        }
+
+        // Let the previous request finish first
+        if (nextQueries) {
+          tracker.fetchEndTime = undefined;
+          tracker.fetchStartTime = Date.now();
+          subscription = options
+            .query({
+              ...req,
+              requestId: `${req.requestId}.${++count}`,
+              startTime: tracker.fetchStartTime,
+              targets: nextQueries,
+            })
+            .subscribe(observer);
+          nextQueries = undefined;
+        } else {
+          subscriber.complete();
+        }
+      },
+    };
+
+    // First request
+    subscription = options.query(req).subscribe(observer);
+
+    return () => {
+      nextQueries = undefined;
+      observer.complete();
+      if (!tracker.fetchEndTime) {
+        options.onCancel(tracker);
+      }
+    };
+  });
+}


### PR DESCRIPTION
Fixes #95 by providing a fallback for paged responses by using the frontend request looper from `v1.x` in instances where Grafana Live is not enabled or available.