### PR TITLE
Fix postResource req body

### DIFF
--- a/pkg/plugin/resource.go
+++ b/pkg/plugin/resource.go
@@ -73,14 +73,15 @@ func (ds *TwinMakerDatasource) HandleListEntityOptions(w http.ResponseWriter, r 
 }
 
 func (ds *TwinMakerDatasource) HandleBatchPutPropertyValues(w http.ResponseWriter, r *http.Request) {
-	entries := make([]*iottwinmaker.PropertyValueEntry, 0)
-
-	err := json.NewDecoder(r.Body).Decode(&entries)
+	req := struct {
+		Entries []*iottwinmaker.PropertyValueEntry `json:"entries"`
+	}{}
+	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"message": "unable to parse request body"}`))
 		return
 	}
-	rsp, err := ds.res.BatchPutPropertyValues(r.Context(), entries)
+	rsp, err := ds.res.BatchPutPropertyValues(r.Context(), req.Entries)
 	writeJsonResponse(w, rsp, err)
 }

--- a/pkg/plugin/resource.go
+++ b/pkg/plugin/resource.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/iottwinmaker"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 func writeJsonResponse(w http.ResponseWriter, rsp interface{}, err error) {
@@ -78,6 +79,7 @@ func (ds *TwinMakerDatasource) HandleBatchPutPropertyValues(w http.ResponseWrite
 	}{}
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
+		log.DefaultLogger.Error("failed to decode request", "error", err)
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"message": "unable to parse request body"}`))
 		return

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -140,7 +140,7 @@ export class TwinMakerDataSource extends DataSourceWithBackend<TwinMakerQuery, T
   }
 
   batchPutPropertyValues = async (entries: Entries): Promise<BatchPutPropertyValuesResponse> => {
-    return super.postResource('entity-properties', entries);
+    return super.postResource('entity-properties', { entries });
   };
 
   // Fetch temporary AWS tokens from the backend plugin and convert them into JS SDK Credentials

--- a/src/panels/alarm-configuration/AlarmConfigurationPanel.tsx
+++ b/src/panels/alarm-configuration/AlarmConfigurationPanel.tsx
@@ -18,7 +18,6 @@ import { TwinMakerDataSource } from 'datasource/datasource';
 
 type Props = PanelProps<PanelOptions>;
 
-const NO_CLIENT = 'TwinMaker client not defined';
 const LOADING = 'Loading...';
 
 export const AlarmConfigurationPanel: React.FunctionComponent<Props> = ({ id, data, options }) => {
@@ -41,12 +40,12 @@ export const AlarmConfigurationPanel: React.FunctionComponent<Props> = ({ id, da
   usePanelRegisteration(id);
 
   useEffect(() => {
-    const doAsync = async() => {
+    const doAsync = async () => {
       const ds = await getTwinMakerDatasource(options.datasource);
       setDataSource(ds);
-    }
+    };
     doAsync();
-  }, [options.datasource])
+  }, [options.datasource]);
 
   useEffect(() => {
     let warning = '';
@@ -71,8 +70,8 @@ export const AlarmConfigurationPanel: React.FunctionComponent<Props> = ({ id, da
   }, [results, queryInfo]);
 
   const updateAlarmThreshold = useCallback(
-    (newThreshold: string) => {
-      const entries: Entries= [
+    (newThreshold: number) => {
+      const entries: Entries = [
         {
           entityPropertyReference: {
             componentName: alarmName,
@@ -83,23 +82,21 @@ export const AlarmConfigurationPanel: React.FunctionComponent<Props> = ({ id, da
             {
               timestamp: new Date(),
               value: {
-                doubleValue: parseFloat(newThreshold),
+                doubleValue: newThreshold,
               },
             },
           ],
-        }
+        },
       ];
-      console.log('as is: ', entries);
-      console.log('to json stringify: ', JSON.stringify(entries));
-      if ( dataSource ) {
-        console.log('try set new threshold', newThreshold);
+      if (dataSource) {
         const doAsync = async () => {
           await dataSource.batchPutPropertyValues(entries);
-        }
+        };
         doAsync();
         setAlarmThreshold(newThreshold);
       }
-    },[alarmName, dataSource, entityId, setAlarmThreshold]
+    },
+    [alarmName, dataSource, entityId, setAlarmThreshold]
   );
 
   const toggleModal = useCallback(() => {

--- a/src/panels/alarm-configuration/AlarmConfigurationPanel.tsx
+++ b/src/panels/alarm-configuration/AlarmConfigurationPanel.tsx
@@ -71,7 +71,7 @@ export const AlarmConfigurationPanel: React.FunctionComponent<Props> = ({ id, da
   }, [results, queryInfo]);
 
   const updateAlarmThreshold = useCallback(
-    (newThreshold: number) => {
+    (newThreshold: string) => {
       const entries: Entries= [
         {
           entityPropertyReference: {
@@ -83,7 +83,7 @@ export const AlarmConfigurationPanel: React.FunctionComponent<Props> = ({ id, da
             {
               timestamp: new Date(),
               value: {
-                doubleValue: newThreshold,
+                doubleValue: parseFloat(newThreshold),
               },
             },
           ],

--- a/src/panels/alarm-configuration/AlarmConfigurationPanel.tsx
+++ b/src/panels/alarm-configuration/AlarmConfigurationPanel.tsx
@@ -1,20 +1,20 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DataQueryRequest, PanelProps } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
 import { Button, LoadingPlaceholder } from '@grafana/ui';
 
-import { PanelOptions } from './types';
+import { Entries } from 'aws-sdk/clients/iottwinmaker';
+
+import { getTwinMakerDatasource } from 'common/datasourceSrv';
 import { TwinMakerQuery } from 'common/manager';
-import { processAlarmQueryInput, processAlarmResult } from './alarmParser';
-
-import { BatchPutPropertyValuesRequest } from 'aws-sdk/clients/iottwinmaker';
-
-import { AlarmEditModal } from './AlarmEditModal';
-
-import { getTemplateSrv } from '@grafana/runtime';
-
 import { usePanelRegisteration } from 'hooks/usePanelRegistration';
 import { useTwinMakerClient } from 'hooks/useTwinMakerClient';
+
+import { AlarmEditModal } from './AlarmEditModal';
+import { processAlarmQueryInput, processAlarmResult } from './alarmParser';
+import { PanelOptions } from './types';
+import { TwinMakerDataSource } from 'datasource/datasource';
 
 type Props = PanelProps<PanelOptions>;
 
@@ -29,6 +29,8 @@ export const AlarmConfigurationPanel: React.FunctionComponent<Props> = ({ id, da
   const [alarmNotificationRecipient, setAlarmNotificationRecipient] = useState('');
   const [warnings, setWarnings] = useState('');
   const [twinMakerClient, dataSourceParams] = useTwinMakerClient(options.datasource);
+  const [dataSource, setDataSource] = useState<TwinMakerDataSource>();
+
   const configured = !!twinMakerClient;
 
   const results = useMemo(() => processAlarmResult(data.series), [data.series]);
@@ -37,6 +39,14 @@ export const AlarmConfigurationPanel: React.FunctionComponent<Props> = ({ id, da
     [data.request]
   );
   usePanelRegisteration(id);
+
+  useEffect(() => {
+    const doAsync = async() => {
+      const ds = await getTwinMakerDatasource(options.datasource);
+      setDataSource(ds);
+    }
+    doAsync();
+  }, [options.datasource])
 
   useEffect(() => {
     let warning = '';
@@ -62,41 +72,34 @@ export const AlarmConfigurationPanel: React.FunctionComponent<Props> = ({ id, da
 
   const updateAlarmThreshold = useCallback(
     (newThreshold: number) => {
-      const request: BatchPutPropertyValuesRequest = {
-        workspaceId: dataSourceParams!.workspaceId,
-        entries: [
-          {
-            entityPropertyReference: {
-              componentName: alarmName,
-              entityId: entityId,
-              propertyName: 'alarm_threshold',
-            },
-            propertyValues: [
-              {
-                timestamp: new Date(),
-                value: {
-                  doubleValue: newThreshold,
-                },
-              },
-            ],
+      const entries: Entries= [
+        {
+          entityPropertyReference: {
+            componentName: alarmName,
+            entityId: entityId,
+            propertyName: 'alarm_threshold',
           },
-        ],
-      };
-      if (twinMakerClient) {
-        twinMakerClient
-          .batchPutPropertyValues(request)
-          .promise()
-          .then(() => {
-            setAlarmThreshold(newThreshold);
-          })
-          .catch((error: any) => {
-            setWarnings(error.message);
-          });
-      } else {
-        console.error(NO_CLIENT);
+          propertyValues: [
+            {
+              timestamp: new Date(),
+              value: {
+                doubleValue: newThreshold,
+              },
+            },
+          ],
+        }
+      ];
+      console.log('as is: ', entries);
+      console.log('to json stringify: ', JSON.stringify(entries));
+      if ( dataSource ) {
+        console.log('try set new threshold', newThreshold);
+        const doAsync = async () => {
+          await dataSource.batchPutPropertyValues(entries);
+        }
+        doAsync();
+        setAlarmThreshold(newThreshold);
       }
-    },
-    [dataSourceParams, alarmName, entityId, twinMakerClient, setAlarmThreshold, setWarnings]
+    },[alarmName, dataSource, entityId, setAlarmThreshold]
   );
 
   const toggleModal = useCallback(() => {

--- a/src/panels/alarm-configuration/AlarmEditModal.tsx
+++ b/src/panels/alarm-configuration/AlarmEditModal.tsx
@@ -17,7 +17,13 @@ export const AlarmEditModal: React.FunctionComponent<AlarmEditProps> = ({
   const [thresholdValue, setThresholdValue] = useState(currentThreshold);
 
   const handleThresholdInputChange = useCallback((event: any) => {
-    setThresholdValue(event.target.value);
+    if (typeof event.target.value === 'string') {
+      setThresholdValue(parseFloat(event.target.value));
+    } else if (typeof event.target.value === 'number') {
+      setThresholdValue(event.target.value);
+    } else {
+      console.error('unknown data type for new threshold');
+    }
   }, []);
 
   const handleSaveClick = useCallback(() => {


### PR DESCRIPTION
### Why
`postResource` specifies `any` for the request body, but expects [the body to be an object](https://github.com/grafana/grafana/blob/cc6fae18db70cd345c11e0545f0b7239cc56b1f4/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts#L240).

### What
Wraps `entries` in an object so that it's compatible with `postResource`.