### PR TITLE
Alarm Configuration: Refresh dashboard after alarm updates

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -5,6 +5,7 @@ export const TWINMAKER_PANEL_TYPE_ID = Object.freeze({
   VIDEO: 'grafana-iot-twinmaker-videoplayer-panel',
   LAYOUT: 'grafana-iot-twinmaker-layout-panel',
   ALARMS: 'grafana-iot-twinmaker-alarm-panel',
+  ALARM_CONFIGURATION: 'grafana-iot-twinmaker-alarm-configuration-panel',
 });
 
 export const TWINMAKER_DATASOURCE_ID = 'grafana-iot-twinmaker-datasource';

--- a/src/common/managerSimple.ts
+++ b/src/common/managerSimple.ts
@@ -15,7 +15,7 @@ export class SimpleTwinMakerDashboardManager implements TwinMakerDashboardManage
 
   /** A list of the scene viewer panels on the dashboard */
   listTwinMakerPanels() {
-    const keep = new Set(Object.values(TWINMAKER_PANEL_TYPE_ID));
+    const keep: Set<string> = new Set(Object.values(TWINMAKER_PANEL_TYPE_ID));
     const dash = getCurrentDashboard();
     // dashboard is not available in explore view
     if (!dash) {

--- a/src/panels/alarm-configuration/AlarmConfigurationPanel.tsx
+++ b/src/panels/alarm-configuration/AlarmConfigurationPanel.tsx
@@ -14,6 +14,7 @@ import { AlarmEditModal } from './AlarmEditModal';
 import { processAlarmQueryInput, processAlarmResult } from './alarmParser';
 import { PanelOptions } from './types';
 import { TwinMakerDataSource } from 'datasource/datasource';
+import { getCurrentDashboard } from 'common/dashboard';
 
 type Props = PanelProps<PanelOptions>;
 
@@ -89,9 +90,10 @@ export const AlarmConfigurationPanel: React.FunctionComponent<Props> = ({ id, da
       if (dataSource) {
         const doAsync = async () => {
           await dataSource.batchPutPropertyValues(entries);
+          setAlarmThreshold(newThreshold);
+          getCurrentDashboard()?.panels?.forEach((panel) => panel.refresh());
         };
         doAsync();
-        setAlarmThreshold(newThreshold);
       }
     },
     [alarmName, dataSource, entityId, setAlarmThreshold]

--- a/src/panels/alarm-configuration/AlarmConfigurationPanel.tsx
+++ b/src/panels/alarm-configuration/AlarmConfigurationPanel.tsx
@@ -36,7 +36,7 @@ export const AlarmConfigurationPanel: React.FunctionComponent<Props> = ({ id, da
   const toField: string | undefined = useMemo(() => {
     // Get variables from the URL
     const queryParams = locationSearchToObject(search || '');
-    return queryParams['to'] ? queryParams['to'] as string : undefined;
+    return queryParams['to'] ? (queryParams['to'] as string) : undefined;
   }, [search]);
 
   const results = useMemo(() => processAlarmResult(data.series), [data.series]);


### PR DESCRIPTION
Fixes issue where updating the Alarm Threshold in View will not have the edit carry over to Edit mode.

Also addresses issue where the dashboard is viewing data in the past and submitting an Alarm Threshold change will update the panel data even though the panel should be using the dashboard time range and thus not change.

Reported by @haweston:
![](https://user-images.githubusercontent.com/360020/207378042-76662f33-31e5-489c-b4a1-8e994b870983.gif)