### PR TITLE
fix(query-filter): Check property description for data type

### DIFF
--- a/src/datasource/components/FilterQueryEditor.tsx
+++ b/src/datasource/components/FilterQueryEditor.tsx
@@ -31,15 +31,15 @@ export default function FilterQueryEditor(props: FilterQueryEditorProps) {
   const stringToFilterValue = (v: string, index: number): TwinMakerFilterValue => {
     const filterVal: TwinMakerFilterValue = {};
     const propSel: SelectableValue<string> | undefined = properties.find((v) => v.value === filters[index].name);
-    if (propSel?.label?.includes('(BOOLEAN)')) {
+    if (propSel?.description?.includes('(BOOLEAN)')) {
       filterVal.booleanValue = v === 'true';
-    } else if (propSel?.label?.includes('(INTEGER)')) {
+    } else if (propSel?.description?.includes('(INTEGER)')) {
       filterVal.integerValue = parseInt(v, 10);
-    } else if (propSel?.label?.includes('(DOUBLE)')) {
+    } else if (propSel?.description?.includes('(DOUBLE)')) {
       filterVal.doubleValue = parseFloat(v);
-    } else if (propSel?.label?.includes('(LONG)')) {
+    } else if (propSel?.description?.includes('(LONG)')) {
       filterVal.longValue = parseFloat(v);
-    } else if (propSel?.label?.includes('(STRING)')) {
+    } else if (propSel?.description?.includes('(STRING)')) {
       filterVal.stringValue = v;
     }
     return filterVal;

--- a/src/datasource/components/QueryEditor.tsx
+++ b/src/datasource/components/QueryEditor.tsx
@@ -554,7 +554,7 @@ export class QueryEditor extends PureComponent<Props, State> {
     onChange(this.changeFilter(query, filterList, isTabularCondition));
   };
 
-  onAddFilter = (isTabularCondition?: boolean) => {
+  onAddFilter = (isTabularCondition?: boolean) => () => {
     const { onChange, query } = this.props;
     let filters = isTabularCondition ? query.tabularConditions?.propertyFilter : query.filter;
     filters = filters ? filters.slice() : [];
@@ -579,7 +579,7 @@ export class QueryEditor extends PureComponent<Props, State> {
       <FilterQueryEditor
         filters={filters}
         properties={properties.options}
-        onAdd={this.onAddFilter}
+        onAdd={this.onAddFilter(isTabularCondition)}
         onChange={this.onFilterChanged}
         isTabularCondition={isTabularCondition}
       />


### PR DESCRIPTION
We check the dataType of the property filter via it's label, but recently the dataType has moved to the description.
https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/pkg/plugin/twinmaker/resource.go#L287

Also fixed a minor bug with the add filter button.