### PR TITLE
Add unlabeled type to trigger removeFromProject

### DIFF
--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -1,9 +1,9 @@
 name: Run commands when issues are labeled
 on:
   issues:
-    types: [labeled]
+    types: [labeled, unlabeled]
   pull_request:
-    types: [labeled]
+    types: [labeled, unlabeled]
     branches-ignore: "dependabot/**"
 jobs:
   main:


### PR DESCRIPTION

**What this PR does / why we need it**: 
Based on https://github.com/grafana/iot-sitewise-datasource/pull/165

Adds the type "unlabeled" so it triggers the removeFromProject action

