### PR TITLE
Update code-coverage.yml

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,9 +1,10 @@
 name: Code Coverage
 on:
   pull_request:
-    branches-ignore: [dependabot/**]
 jobs:
   workflow-call:
+    if: |
+      !startsWith(github.head_ref, 'dependabot')
     uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.17
     with:
       frontend-path-regexp: src


### PR DESCRIPTION
**Motivation**: `pull_request` is actually describing the target branch. So the check for the name of the PR branch is handled in `if: !startsWith(github.head_ref, 'dependabot')`
See the doc page here:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
>To run a job based on the pull request's head branch name (as opposed to the pull request's base branch name), use the github.head_ref context in a conditional.

**Description**:This change makes it so that any PR branch which starts with `dependabot` skips the Code Coverage workflow.

Part of https://github.com/grafana/code-coverage/issues/17 