### PR TITLE
feat(TwinMaker): Setting up sticky video controls

### DIFF
--- a/src/panels/video-player/VideoPlayer.tsx
+++ b/src/panels/video-player/VideoPlayer.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { getStyles } from './styles';
+import { getVideoPlayerStyles, getRequestVideoUploadStyles } from './styles';
 import { VideoPlayerPropsFromParent } from './interfaces';
 import { auto } from '@popperjs/core';
 import { locationSearchToObject } from '@grafana/runtime';
@@ -12,7 +12,8 @@ import { RequestVideoUpload, VideoPlayer as VideoPlayerComp } from '@iot-app-kit
 
 export const VideoPlayer = (props: VideoPlayerPropsFromParent) => {
   const { replaceVariables } = props;
-  const styles = getStyles();
+  const videoPlayerStyles = getVideoPlayerStyles();
+  const requestVideoUploadStyles = getRequestVideoUploadStyles();
 
   const { search } = useLocation();
 
@@ -114,11 +115,15 @@ export const VideoPlayer = (props: VideoPlayerPropsFromParent) => {
     <div
       data-testid={'VideoPlayer'}
       // Fit video player inside panel
-      className={styles.wrapper}
+      className={videoPlayerStyles.wrapper}
       style={{ width: props.width, height: props.height, overflow: auto }}
     >
       {videoData && <VideoPlayerComp videoData={videoData} viewport={viewport} />}
-      {videoData && <RequestVideoUpload videoData={videoData} />}
+      {videoData && (
+        <div className={requestVideoUploadStyles.wrapper}>
+          <RequestVideoUpload videoData={videoData} />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/panels/video-player/styles.ts
+++ b/src/panels/video-player/styles.ts
@@ -1,9 +1,18 @@
 import { css } from '@emotion/css';
 
-export const getStyles = () => {
+export const getVideoPlayerStyles = () => {
   return {
     wrapper: css`
       position: relative;
     `,
   };
 };
+
+export const getRequestVideoUploadStyles = () => {
+  return {
+    wrapper: css`
+      position: sticky;
+      bottom: 0;
+    `,
+  };
+}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:

- Improves video player user experience.

**Which issue(s) this PR fixes**:

- Applies sticky placement to the `video-upload-request-ui` block.

**Special notes for your reviewer**:


https://user-images.githubusercontent.com/6610619/236571832-afe35cb2-c4df-4e48-a09d-bd18500a5b63.mov



