### PR TITLE
Edit codeowner permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,9 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-* @grafana/aws-datasources
+# Grafana AWS datasources owns the datasource plugin code
+/.github/ @grafana/aws-datasources
+/go.mod @grafana/aws-datasources
+/go.sum @grafana/aws-datasources
+/pkg/ @grafana/aws-datasources
+/src/datasource/ @grafana/aws-datasources


### PR DESCRIPTION
Reduces our (the grafana team's) code ownership to just the github files, the go code, and the frontend datasource code. Hopefully this improves the Twinmaker team's development experience.

Notes:
According to [this](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) I'm fairly sure the un-owned code will not have us as code owners and thus will not require our approval to be merged. I can add other files if we think that we should be controlling access to them.