### PR TITLE
Query editor: Improve workspace loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@swc/jest": "^0.2.23",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",
+    "@testing-library/user-event": "^14.4.3",
     "@types/glob": "^8.0.0",
     "@types/jest": "^29.2.2",
     "@types/lodash": "^4.14.188",

--- a/src/common/info/info.ts
+++ b/src/common/info/info.ts
@@ -77,9 +77,9 @@ export function resolvePropsFromComponentSel(
   return propOpts;
 }
 
-const handleValueNotFound = <T = any>(value: T) => {
+const handleValueNotFound = <T = any>(value: T, showNotFound = true) => {
   const current = {
-    label: `${value} (not found)`,
+    label: `${value} ${showNotFound ? '(not found)' : ''}`,
     value,
   };
   if (current.label!.indexOf('$') >= 0) {
@@ -151,7 +151,8 @@ export interface SelectionInfo<T = any> {
 export function getSelectionInfo<T>(
   v?: T,
   options?: Array<SelectableValue<T>>,
-  templateVars?: Array<SelectableValue<T>>
+  templateVars?: Array<SelectableValue<T>>,
+  allowCustom?: boolean
 ): SelectionInfo<T> {
   if (v && !options) {
     const current = { label: `${v}`, value: v };
@@ -169,7 +170,7 @@ export function getSelectionInfo<T>(
   }
 
   if (v && !current) {
-    current = handleValueNotFound(v);
+    current = handleValueNotFound(v, false);
     options.push(current);
   }
   return {

--- a/src/datasource/components/ConfigEditor.test.tsx
+++ b/src/datasource/components/ConfigEditor.test.tsx
@@ -1,7 +1,94 @@
+import React from 'react';
+import { ConfigEditor } from './ConfigEditor';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AwsAuthType } from '@grafana/aws-sdk';
+import { DataSourceSettings } from '@grafana/data';
+import { TwinMakerDataSourceOptions, TwinMakerSecureJsonData } from 'datasource/types';
+
+const datasourceOptions: DataSourceSettings<TwinMakerDataSourceOptions, TwinMakerSecureJsonData> = {
+  id: 0,
+  uid: 'test',
+  orgId: 0,
+  name: 'twinmaker',
+  typeLogoUrl: '',
+  type: 'datasource',
+  typeName: 'Datasource',
+  access: 'server',
+  url: 'http://localhost',
+  user: '',
+  database: '',
+  basicAuth: false,
+  basicAuthUser: '',
+  isDefault: false,
+  jsonData: {},
+  readOnly: false,
+  withCredentials: false,
+  secureJsonFields: {},
+  password: 'test',
+  basicAuthPassword: 'password',
+};
+const workspacesMock = jest.fn(() => Promise.resolve([{ value: 'test1', label: 'test1' }]));
+
+jest.mock('common/datasourceSrv', () => ({
+  ...jest.requireActual('common/datasourceSrv'),
+  getTwinMakerDatasource: jest.fn(() => ({
+    info: {
+      listWorkspaces: workspacesMock,
+    },
+  })),
+}));
+
+function setup() {
+  return {
+    user: userEvent.setup(),
+    ...render(<ConfigEditor onOptionsChange={() => {}} options={datasourceOptions} />),
+  };
+}
+
+const resetWindow = () => {
+  (window as any).grafanaBootData = {
+    settings: {
+      awsAllowedAuthProviders: [AwsAuthType.EC2IAMRole, AwsAuthType.Keys],
+      awsAssumeRoleEnabled: false,
+    },
+  };
+};
+
 describe('ConfigEditor', () => {
-    describe('loading workspaces', () => {
-        it('should display an error if the datasource is not loaded', () => {
-            
-        })
-    })
-})
+  beforeEach(() => resetWindow());
+  describe('loading workspaces', () => {
+    it('should display an error if the datasource is not saved', async () => {
+      const { rerender, user } = setup();
+      const rerenderOptions = {
+        ...datasourceOptions,
+        jsonData: {
+          assumeRoleArn: 'test_2',
+        },
+      };
+      rerender(<ConfigEditor options={rerenderOptions} onOptionsChange={() => {}} />);
+      const dropdown = screen.getByText('Select a workspace');
+      await user.click(dropdown);
+      const error = await screen.findByText('Save the datasource first to load workspaces');
+      expect(error).toBeInTheDocument();
+      expect(workspacesMock).not.toHaveBeenCalled();
+      
+    });
+    it('should remove the error when the datasource is saved', async () => {
+      const { rerender, user } = setup();
+      const rerenderOptions = {
+        ...datasourceOptions,
+        jsonData: {
+          assumeRoleArn: 'test_2',
+        },
+      };
+      rerender(<ConfigEditor options={rerenderOptions} onOptionsChange={() => {}} />);
+      const dropdown = screen.getByText('Select a workspace');
+      await user.click(dropdown);
+      const error = await screen.findByText('Save the datasource first to load workspaces');
+      expect(error).toBeInTheDocument();
+      rerender(<ConfigEditor options={{...rerenderOptions, version: 2}} onOptionsChange={() => {}} />);
+      waitFor(() => expect(error).not.toBeInTheDocument());
+    });
+  });
+});

--- a/src/datasource/components/ConfigEditor.test.tsx
+++ b/src/datasource/components/ConfigEditor.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ConfigEditor } from './ConfigEditor';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { AwsAuthType } from '@grafana/aws-sdk';
 import { DataSourceSettings } from '@grafana/data';
 import { TwinMakerDataSourceOptions, TwinMakerSecureJsonData } from 'datasource/types';
 

--- a/src/datasource/components/ConfigEditor.test.tsx
+++ b/src/datasource/components/ConfigEditor.test.tsx
@@ -49,8 +49,6 @@ function setup() {
 const resetWindow = () => {
   (window as any).grafanaBootData = {
     settings: {
-      awsAllowedAuthProviders: [AwsAuthType.EC2IAMRole, AwsAuthType.Keys],
-      awsAssumeRoleEnabled: false,
     },
   };
 };

--- a/src/datasource/components/ConfigEditor.test.tsx
+++ b/src/datasource/components/ConfigEditor.test.tsx
@@ -1,0 +1,7 @@
+describe('ConfigEditor', () => {
+    describe('loading workspaces', () => {
+        it('should display an error if the datasource is not loaded', () => {
+            
+        })
+    })
+})

--- a/src/datasource/components/ConfigEditor.tsx
+++ b/src/datasource/components/ConfigEditor.tsx
@@ -106,13 +106,7 @@ export function ConfigEditor(props: Props) {
 
       <FieldSet label={'TwinMaker settings'} data-testid="twinmaker-settings">
         <InlineFieldRow>
-          <InlineField
-            label="Workspace"
-            labelWidth={28}
-            required={true}
-            invalid={!!workspacesError}
-            error={workspacesError}
-          >
+          <InlineField label="Workspace" labelWidth={28} invalid={!!workspacesError} error={workspacesError}>
             <Select
               menuShouldPortal={true}
               value={workspacesSelection.current}

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -19,7 +19,7 @@ export class TwinMakerDataSource extends DataSourceWithBackend<TwinMakerQuery, T
 
   constructor(public instanceSettings: DataSourceInstanceSettings<TwinMakerDataSourceOptions>) {
     super(instanceSettings);
-
+    
     this.workspaceId = instanceSettings.jsonData.workspaceId!;
     this.grafanaLiveEnabled = true;
 
@@ -167,4 +167,5 @@ export class TwinMakerDataSource extends DataSourceWithBackend<TwinMakerQuery, T
     };
     return credentials;
   };
+  
 }

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -19,7 +19,6 @@ export class TwinMakerDataSource extends DataSourceWithBackend<TwinMakerQuery, T
 
   constructor(public instanceSettings: DataSourceInstanceSettings<TwinMakerDataSourceOptions>) {
     super(instanceSettings);
-    
     this.workspaceId = instanceSettings.jsonData.workspaceId!;
     this.grafanaLiveEnabled = true;
 
@@ -167,5 +166,4 @@ export class TwinMakerDataSource extends DataSourceWithBackend<TwinMakerQuery, T
     };
     return credentials;
   };
-  
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5803,6 +5803,11 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "<18.0.0"
 
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:
Implements logic for only fetching workspaces when 
- the datasource is saved
- the dropdown is clicked


As described in [this ticket](https://github.com/grafana/grafana-iot-twinmaker-app/issues/154), the workspace handling was confusing and there wasn't info that the DS should be saved before selecting workspaces. 
It looks like this now: 

With new datasource
![twinm_1](https://github.com/grafana/grafana-iot-twinmaker-app/assets/16140639/59fcf3ab-5e52-42fe-b3db-3cc13c7a66f7)

With an already saved datasource:
![ezgif-4-b54b782e5e](https://github.com/grafana/grafana-iot-twinmaker-app/assets/16140639/ff89ec23-1bb6-4701-9cbe-f05de2b28031)

The only thing I don't love right now is that there is an error for missing workspace when the user saves for the first time. Lmk if you want me to spend some time on improving that. 


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-iot-twinmaker-app/issues/154

**Special notes for your reviewer**:
I also refactored the component from class to function