### PR TITLE
Config Editor: Open Workspaces menu on the top

### DIFF
--- a/src/datasource/components/ConfigEditor.tsx
+++ b/src/datasource/components/ConfigEditor.tsx
@@ -108,6 +108,7 @@ export function ConfigEditor(props: Props) {
         <InlineFieldRow>
           <InlineField label="Workspace" labelWidth={28} invalid={!!workspacesError} error={workspacesError}>
             <Select
+              menuPlacement="top"
               menuShouldPortal={true}
               value={workspacesSelection.current}
               options={workspacesSelection.options}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:
When the user (me) opens the workspaces menu, there often isn't enough room on the bottom for the whole menu to be visible:
<img width="500" alt="Screenshot 2023-06-28 at 12 54 24 PM" src="https://github.com/grafana/grafana-iot-twinmaker-app/assets/16140639/83c727b5-7cb3-426f-a8e9-60167c8f22be">
After: 

<img width="500" alt="Screenshot 2023-06-28 at 12 54 02 PM" src="https://github.com/grafana/grafana-iot-twinmaker-app/assets/16140639/06e2165d-3513-4aea-94c2-e1cde3cf9303">

This change makes it open on the top. Don't love that the menu doesn't stand out, but I think this is an improvement nonetheless? 🤔

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
