### PR TITLE
fix 'invalid url' when endpoint is empty string

### DIFF
--- a/src/panels/oldStuffFromDatasource.ts
+++ b/src/panels/oldStuffFromDatasource.ts
@@ -29,7 +29,7 @@ export class OldDatasourceStuff {
     this.appKitTMDataSource = initialize(this.workspaceId, {
       awsCredentials: ds.getTokensV3,
       awsRegion: ds.instanceSettings.jsonData.defaultRegion || defaultRegion,
-      tmEndpoint: endpoint,
+      tmEndpoint: endpoint || undefined, // if endpoint is emptry string, prefer undefined
     });
   }
 

--- a/src/panels/oldStuffFromDatasource.ts
+++ b/src/panels/oldStuffFromDatasource.ts
@@ -29,7 +29,7 @@ export class OldDatasourceStuff {
     this.appKitTMDataSource = initialize(this.workspaceId, {
       awsCredentials: ds.getTokensV3,
       awsRegion: ds.instanceSettings.jsonData.defaultRegion || defaultRegion,
-      tmEndpoint: endpoint || undefined, // if endpoint is emptry string, prefer undefined
+      tmEndpoint: endpoint || undefined, // if endpoint is empty string, prefer undefined
     });
   }
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->


**Which issue(s) this PR fixes**:

Fixes # https://github.com/grafana/grafana-iot-twinmaker-app/issues/203

**Special notes for your reviewer**:

When endpoint value is an empty string, (which happens when configuring the data source, typing in the endpoint field and then deleting), unexpected bugs were occurring like the bug in the linked issue.

To reproduce, follow the steps [here](https://github.com/grafana/grafana-iot-twinmaker-app/issues/203#issuecomment-1660721032) and you should no longer see the error.
