### PR TITLE
Wrap QueryEditor panel plugin in CustomScrollbar to fix scrolling behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.8.1
 
-- Wrap QueryEditor panel plugin in CustomScrollbar to fix scrolling behaviour in [#223](https://github.com/grafana/grafana-iot-twinmaker-app/pull/223)
+- Wrap QueryEditor panel plugin in CustomScrollbar to fix scrolling behavior in [#223](https://github.com/grafana/grafana-iot-twinmaker-app/pull/223)
 
 ## 1.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.1
+
+- Wrap QueryEditor panel plugin in CustomScrollbar to fix scrolling behaviour in [#223](https://github.com/grafana/grafana-iot-twinmaker-app/pull/223)
+
 ## 1.8.0
 
 - Upgrade plugin dependencies to React 18 and iot-app-kit@7 in [#212](https://github.com/grafana/grafana-iot-twinmaker-app/pull/212)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-twinmaker-app",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Grafana IoT TwinMaker App Plugin",
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=4096' webpack -c webpack.config.ts --env production ",

--- a/src/panels/query-editor/QueryEditor.tsx
+++ b/src/panels/query-editor/QueryEditor.tsx
@@ -3,7 +3,8 @@ import 'aws-iot-twinmaker-grafana-utils/dist/index.css';
 
 import { QueryEditorPropsFromParent } from './interfaces';
 import { QueryBuilder } from 'aws-iot-twinmaker-grafana-utils';
+import { CustomScrollbar } from '@grafana/ui';
 
 export const QueryEditor = (props: QueryEditorPropsFromParent) => {
-  return <QueryBuilder workspaceId={props.workspaceId} awsConfig={props.awsConfig} />;
+  return <CustomScrollbar><QueryBuilder workspaceId={props.workspaceId} awsConfig={props.awsConfig} /></CustomScrollbar>;
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:
As suggested [here](https://github.com/grafana/grafana/issues/75422#issuecomment-1736278952), we can wrap the Query Editor panel in the CustomScrollbar component from @grafana/ui to restore the scrolling behaviour. This is how it looks now (tested in Grafana 10 and 9):

<img width="1065" alt="Screenshot 2023-09-27 at 11 13 51 AM" src="https://github.com/grafana/grafana-iot-twinmaker-app/assets/16140639/26f69d50-701b-4180-9b6b-e0696abb4d6f">


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-iot-twinmaker-app/issues/224

**Special notes for your reviewer**:
