### PR TITLE
Support for ap-south-1 (BOM), ap-northeast-1 (NRT), & ap-northeast-2 …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.9.0
+
+- Support for new regions ap-south-1 (BOM), ap-northeast-1 (NRT), & ap-northeast-2 (ICN) in datasource
+- Fix to allow custom cell types to display images
+
 ## 1.8.1
 
 - Wrap QueryEditor panel plugin in CustomScrollbar to fix scrolling behavior in [#223](https://github.com/grafana/grafana-iot-twinmaker-app/pull/223)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-twinmaker-app",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Grafana IoT TwinMaker App Plugin",
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=4096' webpack -c webpack.config.ts --env production ",

--- a/src/datasource/regions.ts
+++ b/src/datasource/regions.ts
@@ -1,6 +1,9 @@
 import { SelectableValue } from '@grafana/data';
 
 export const standardRegions = [
+  'ap-south-1',
+  'ap-northeast-1',
+  'ap-northeast-2',
   'ap-southeast-1',
   'ap-southeast-2',
   'eu-central-1',


### PR DESCRIPTION
…(ICN)

<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:
IoT TwinMaker is launching to the ap-south-1 (BOM), ap-northeast-1 (NRT), & ap-northeast-2 (ICN) region, so we need to add these regions as an option in the datasource region dropdown. The AWS SDK already supports these regions so the backend/frontend code will not need to be updated any more.


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
