### PR TITLE
fix(Matterport-Scene): Use specific version of Matterport SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support for new regions ap-south-1 (BOM), ap-northeast-1 (NRT), & ap-northeast-2 (ICN) in datasource
 - Fix to allow custom cell types to display images
+- Fix to load a scene with Matterport space in the scene viewer
 
 ## 1.8.1
 

--- a/package.json
+++ b/package.json
@@ -125,6 +125,8 @@
     "video.js": "8.3.0",
     "@react-three/drei": "8.11.0",
     "@react-three/fiber": "7.0.26",
-    "@react-three/test-renderer": "7.0.27"
+    "@react-three/test-renderer": "7.0.27",
+    "@matterport/r3f": "0.2.6",
+    "@matterport/webcomponent": "0.1.26"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5031,15 +5031,15 @@
   resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz#15651bd553a67b8581fb398810c98ad86a34524e"
   integrity sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==
 
-"@matterport/r3f@^0.2.6":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@matterport/r3f/-/r3f-0.2.7.tgz#05acf38987d6fb02fc9004f17d11fe4d2db485ad"
-  integrity sha512-vw8dJNvYq3DvCff+bk5USvVDtObbJShsTSc7leo5FpG5/9BLejZ4quGbhIDxG9ndQhQe2th2boTfUCv4OxdU7A==
+"@matterport/r3f@0.2.6", "@matterport/r3f@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@matterport/r3f/-/r3f-0.2.6.tgz#eebf5dc70e6cd5513c25c8614d74ab79ec0d5edb"
+  integrity sha512-IdRCwGzJLlCvu/IO8uiEFh63roa5Dthba7Fu86KeaqCgMUyILrdx2sW8xs8u60rzHAE1QMV2n9XiTmijdqF6bQ==
 
-"@matterport/webcomponent@^0.1.26":
-  version "0.1.30"
-  resolved "https://registry.yarnpkg.com/@matterport/webcomponent/-/webcomponent-0.1.30.tgz#a39702e8cabddaa7e595f794e4303e27894f6464"
-  integrity sha512-MDbG9kn01kQFaREpLGoGGWjtf3QlNhH5mYKnUBrJc2cQOPnUYAEa8T/Rbv/Wvq7C5+A3NgcbemkIUNjKLBYTng==
+"@matterport/webcomponent@0.1.26", "@matterport/webcomponent@^0.1.26":
+  version "0.1.26"
+  resolved "https://registry.yarnpkg.com/@matterport/webcomponent/-/webcomponent-0.1.26.tgz#550f3dc64e16d70f0716aa37c8a558c6facc4a5e"
+  integrity sha512-W9oHhQx4kdycNbEeo+KYnrrz+tHwgC8kiV/sTWPZspXvI4+Yje2upTKB1N414NvZViaWP2kgb4hKZyYDNNGtPQ==
   dependencies:
     lit "^2.4.1"
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:

There is a problem in loading the Scene with Matterport space due to a bug in the latest Matterport SDKs. Reverted the Matterport SDK versions to the last working versions.
These are the same versions used in the iot-app-kit.

**Which issue(s) this PR fixes**:

Fixes #232 

**Special notes for your reviewer**: No impact on other functionalities
