### PR TITLE
Fix imported Alarm Dashboard's filter value from string to struct

### DIFF
--- a/src/datasource/dashboards/twinmaker-alarm-dashboard.json
+++ b/src/datasource/dashboards/twinmaker-alarm-dashboard.json
@@ -296,7 +296,9 @@
             {
               "name": "alarm_status",
               "op": "=",
-              "value": "ACTIVE"
+              "value": {
+                "stringValue": "ACTIVE"
+              }
             }
           ],
           "order": "DESCENDING",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:
This PR changes the dashboard JSON's filter value from a simple string to the expected struct.
The structure changed about a year ago: https://github.com/grafana/grafana-iot-twinmaker-app/pull/118/files#diff-c4f0fcff0253fa91c051c3b3a8897168273aa7c3a5cc78b9dbfbaa58f21a88d0L34

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-iot-twinmaker-app/issues/239

**Special notes for your reviewer**:
Here's how this change looks (no more error and ACTIVE is set):
![Screenshot 2023-11-01 at 15 21 30](https://github.com/grafana/grafana-iot-twinmaker-app/assets/4163034/f2ac1e25-a3a9-4690-8390-988673f9b0c8)
