### PR TITLE
New Feature requests open as github issues rather than discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Feature Request
-    url: https://github.com/grafana/grafana-iot-twinmaker-app/discussions/new?category=ideas
-    about: Discuss ideas for new features or changes
   - name: Questions & Help
     url: https://community.grafana.com
     about: Please ask and answer questions here

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: ['datasource/TwinMaker', 'type/feature-request']
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
As part of our work to shift from discussions to github issues we'd like to ensure that all new feature requests open as github issues. 

See https://github.com/grafana/grafana/discussions/73424