### PR TITLE
Prepare v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.9.2
+
+- Bump go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace from 0.42.0 to 0.44.0 by @dependabot in https://github.com/grafana/grafana-iot-twinmaker-app/pull/237
+- Fix imported Alarm Dashboard's filter value from string to struct by @fridgepoet in https://github.com/grafana/grafana-iot-twinmaker-app/pull/240
+- Bump @babel/traverse from 7.22.15 to 7.23.2 by @dependabot in https://github.com/grafana/grafana-iot-twinmaker-app/pull/241
+- Bump google.golang.org/grpc from 1.58.2 to 1.58.3 by @dependabot in https://github.com/grafana/grafana-iot-twinmaker-app/pull/242
+
 ## 1.9.1
 
 - Support for custom style for tags in the Scene Viewer panel

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -53,6 +53,11 @@
     "videoplayer",
     "commitish",
     "matterport",
-    "raycast"
+    "raycast",
+    "opentelemetry",
+    "httptrace",
+    "otelhttptrace",
+    "struct",
+    "fridgepoet"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-twinmaker-app",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Grafana IoT TwinMaker App Plugin",
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=4096' webpack -c webpack.config.ts --env production ",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:

- Bump go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace from 0.42.0 to 0.44.0 by @dependabot in https://github.com/grafana/grafana-iot-twinmaker-app/pull/237
- Fix imported Alarm Dashboard's filter value from string to struct by @fridgepoet in https://github.com/grafana/grafana-iot-twinmaker-app/pull/240
- Bump @babel/traverse from 7.22.15 to 7.23.2 by @dependabot in https://github.com/grafana/grafana-iot-twinmaker-app/pull/241
- Bump google.golang.org/grpc from 1.58.2 to 1.58.3 by @dependabot in https://github.com/grafana/grafana-iot-twinmaker-app/pull/242
