### PR TITLE
Prepare 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.10.0
+
+- Add ramda 0.27.2 to resolutions [#256](https://github.com/grafana/grafana-iot-twinmaker-app/pull/256)
+- Query editor: Migrate to new form styling under feature toggle in [#249](https://github.com/grafana/grafana-iot-twinmaker-app/pull/249)
+- Config editor: Migrate to new form styling under feature toggle in [#244](https://github.com/grafana/grafana-iot-twinmaker-app/pull/244)
+
 ## 1.9.3
 
 - Upgrade IotAppKit dependency from 9.2.0 to 9.6.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-twinmaker-app",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "Grafana IoT TwinMaker App Plugin",
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=4096' webpack -c webpack.config.ts --env production ",


### PR DESCRIPTION
## 1.10.0

- Add ramda 0.27.2 to resolutions [#256](https://github.com/grafana/grafana-iot-twinmaker-app/pull/256)
- Query editor: Migrate to new form styling under feature toggle in [#249](https://github.com/grafana/grafana-iot-twinmaker-app/pull/249)
- Config editor: Migrate to new form styling under feature toggle in [#244](https://github.com/grafana/grafana-iot-twinmaker-app/pull/244)
