### PR TITLE
Config editor: Fix workspace loading in new form styling and prepare 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.10.0
+
+- Add ramda 0.27.2 to resolutions [#256](https://github.com/grafana/grafana-iot-twinmaker-app/pull/256)
+- Query editor: Migrate to new form styling under feature toggle in [#249](https://github.com/grafana/grafana-iot-twinmaker-app/pull/249)
+- Config editor: Migrate to new form styling under feature toggle in [#244](https://github.com/grafana/grafana-iot-twinmaker-app/pull/244)
+
 ## 1.9.3
 
 - Upgrade IotAppKit dependency from 9.2.0 to 9.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.10.0
 
-- Add ramda 0.27.2 to resolutions [#256](https://github.com/grafana/grafana-iot-twinmaker-app/pull/256)
+- Config editor: Fix workspace loading in new form styling in [#258](https://github.com/grafana/grafana-iot-twinmaker-app/pull/258)
+- Add ramda 0.27.2 to resolutions in [#256](https://github.com/grafana/grafana-iot-twinmaker-app/pull/256)
 - Query editor: Migrate to new form styling under feature toggle in [#249](https://github.com/grafana/grafana-iot-twinmaker-app/pull/249)
 - Config editor: Migrate to new form styling under feature toggle in [#244](https://github.com/grafana/grafana-iot-twinmaker-app/pull/244)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-twinmaker-app",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "Grafana IoT TwinMaker App Plugin",
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=4096' webpack -c webpack.config.ts --env production ",

--- a/src/datasource/components/ConfigEditor.tsx
+++ b/src/datasource/components/ConfigEditor.tsx
@@ -110,7 +110,11 @@ export function ConfigEditor(props: Props) {
         <>
           <Divider />
           <ConfigSection title="Twinmaker Settings" data-testid="twinmaker-settings">
-            <Field label="Workspace" invalid={!!workspacesError} error={workspacesError}>
+            <Field
+              label="Workspace"
+              invalid={!!workspacesError}
+              error={workspacesError}
+            >
               <Select
                 menuPlacement="top"
                 menuShouldPortal={true}
@@ -123,7 +127,6 @@ export function ConfigEditor(props: Props) {
                 onCreateOption={onUnknownWorkspaceChange}
                 formatCreateLabel={(v) => `WorkspaceID: ${v}`}
                 isClearable={true}
-                disabled={workspaces?.length === 0}
                 placeholder="Select a workspace"
                 noOptionsMessage="No workspaces found"
                 onOpenMenu={onOpenHandler}

--- a/src/datasource/components/ConfigEditor.tsx
+++ b/src/datasource/components/ConfigEditor.tsx
@@ -110,11 +110,7 @@ export function ConfigEditor(props: Props) {
         <>
           <Divider />
           <ConfigSection title="Twinmaker Settings" data-testid="twinmaker-settings">
-            <Field
-              label="Workspace"
-              invalid={!!workspacesError}
-              error={workspacesError}
-            >
+            <Field label="Workspace" invalid={!!workspacesError} error={workspacesError}>
               <Select
                 menuPlacement="top"
                 menuShouldPortal={true}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:

In the old form styling, the Workspaces Select input was set to be disabled if there were no workspaces. This doesn't seem to do anything, since the default state is `[]` but the user is still able to click on it. This is ok, since the fetchWorkspaces function is only called on opening the dropdown. 
However, in the new form styling the `disabled` attribute is applied, so the user is unable to fetch workspaces for a new Twinmaker datasource. Probably should have caught this earlier, but better late than never I guess 😔

I removed the disabled attribute, since the flow works perfectly fine without it (i.e. the same as in the old form styling). 

![ezgif-2-1bfa1cad82](https://github.com/grafana/grafana-iot-twinmaker-app/assets/16140639/d2dac521-ed48-48e1-885c-c676f065516b)


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
