### PR TITLE
Convert time objects to strings with nanosecond precision

### DIFF
--- a/pkg/plugin/twinmaker/utils.go
+++ b/pkg/plugin/twinmaker/utils.go
@@ -402,6 +402,6 @@ func getTimeObjectFromStringTime(timeString *string) (*time.Time, error) {
 }
 
 func getTimeStringFromTimeObject(timeObject *time.Time) *string {
-	timeString := timeObject.Format(time.RFC3339)
+	timeString := timeObject.Format(time.RFC3339Nano)
 	return &timeString
 }

--- a/pkg/plugin/twinmaker/utils_test.go
+++ b/pkg/plugin/twinmaker/utils_test.go
@@ -89,7 +89,7 @@ func TestGetTimeObjectFromStringTime(t *testing.T) {
 
 func TestGetTimeStringFromTimeObject(t *testing.T) {
 	t.Run("Convert time object to ISO 8601 date time string", func(t *testing.T) {
-		timeObject := time.Date(2022, 4, 27, 0, 0, 0, 0, time.UTC)
-		require.Equal(t, "2022-04-27T00:00:00Z", *getTimeStringFromTimeObject(&timeObject))
+		timeObject := time.Date(2022, 4, 27, 0, 0, 0, 123456789, time.UTC)
+		require.Equal(t, "2022-04-27T00:00:00.123456789Z", *getTimeStringFromTimeObject(&timeObject))
 	})
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:
A community member followed a tutorial for setting up Twinmaker that had timestamp in unix time. They were getting [duplicated results](https://github.com/grafana/grafana-iot-twinmaker-app/issues/263) due to the plugin sending time string to GetPropertyValueHistory in string with only second precision. 

When we query streaming, we set the startTime to the latest timestamp of the previous set of results. The startTime we were sending was always set to second + 0 milliseconds (second precision): `timeObject.Format(time.RFC3339)`, so it would always actually query ***before*** the last timestamp. 
For example, our last entry was at `2024-01-08T19:58:34.123+01:00`.  The util function was parsing it into `2024-01-08T19:58:34+01:00`, losing the milliseconds. 
When parsed into unix millisecond timestamp, the original last entry is at 1704740314123, but ours ends up being 1704740314000, before that. This is why the lambda always returns the last entry. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-iot-twinmaker-app/issues/263

**Special notes for your reviewer**:
