### PR TITLE
Support for cn-north-1 (BJS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.11.0
+
+- Support for new region cn-north-1 (BJS) in datasource
+
 ## 1.10.1
 
 - Fixed scene loading issue for Grafana version 9.x and below

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-twinmaker-app",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Grafana IoT TwinMaker App Plugin",
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=4096' webpack -c webpack.config.ts --env production ",

--- a/src/datasource/regions.ts
+++ b/src/datasource/regions.ts
@@ -11,6 +11,7 @@ export const standardRegions = [
   'us-east-1',
   'us-west-2',
   'us-gov-west-1',
+  'cn-north-1',
 ];
 
 export const standardRegionOptions: Array<SelectableValue<string>> = standardRegions.map((v) => ({


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:
IoT TwinMaker is launching to the cn-north-1 (BJS) region, so we need to add this region as an option in the datasource region dropdown.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
