### PR TITLE
Prepare 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## 1.11.1
+
+- Query Editor: Disable delete if only one filter, fix tooltip (new form styling) in [#268](https://github.com/grafana/grafana-iot-twinmaker-app/pull/268)
+- GetPropertyValueHistory: Convert time objects to strings with nanosecond precision [#264](https://github.com/grafana/grafana-iot-twinmaker-app/pull/264)
+
 ## 1.11.0
 
 - Support for new region cn-north-1 (BJS) in datasource

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-twinmaker-app",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Grafana IoT TwinMaker App Plugin",
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=4096' webpack -c webpack.config.ts --env production ",


### PR DESCRIPTION
## 1.11.1

- Query Editor: Disable delete if only one filter, fix tooltip (new form styling) in [#268](https://github.com/grafana/grafana-iot-twinmaker-app/pull/268)
- GetPropertyValueHistory: Convert time objects to strings with nanosecond precision [#264](https://github.com/grafana/grafana-iot-twinmaker-app/pull/264)