### PR TITLE
Add nested plugin to app includes

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -25,7 +25,33 @@
   "includes": [
     {
       "type": "datasource",
-      "name": "Grafana IoT TwinMaker Datasource"
+      "name": "Grafana IoT TwinMaker Datasource",
+      "path": "datasource/plugin.json"
+    },
+    {
+        "type": "panel",
+        "name": "AWS IoT TwinMaker Alarm Configuration Panel",
+        "path": "panels/alarm/plugin.json"
+    },
+    {
+        "type": "panel",
+        "name": "Grafana IoT TwinMaker Dashboard Layout Panel",
+        "path": "panels/layout/plugin.json"
+    },
+    {
+        "type": "panel",
+        "name": "AWS IoT TwinMaker Query Editor Panel",
+        "path": "panels/query-editor/plugin.json"
+    },
+    {
+        "type": "panel",
+        "name": "AWS IoT TwinMaker Scene Viewer Panel",
+        "path": "panels/scene-viewer/plugin.json"
+    },
+    {
+        "type": "panel",
+        "name": "AWS IoT TwinMaker Video Player Panel",
+        "path": "panels/video-player/plugin.json"
     }
   ],
 


### PR DESCRIPTION
This ensures that we are able to serve the twinmaker app from the plugin CDN.

Note: Given the naming of the `plugin.json` file of the nested alarm panel (`plugin_SKIP.json`) - this has been omitted as it will not be loaded by Grafana anyway.