### PR TITLE
Migrate to new form styling in config and query editors

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.7",
     "@emotion/css": "^11.1.3",
-    "@grafana/aws-sdk": "0.3.1",
+    "@grafana/aws-sdk": "0.4.0",
     "@grafana/data": "10.2.0",
     "@grafana/eslint-config": "^5.1.0",
     "@grafana/runtime": "10.2.0",

--- a/src/datasource/components/ConfigEditor.test.tsx
+++ b/src/datasource/components/ConfigEditor.test.tsx
@@ -4,7 +4,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DataSourceSettings } from '@grafana/data';
 import { TwinMakerDataSourceOptions, TwinMakerSecureJsonData } from 'datasource/types';
-import { config } from '@grafana/runtime';
 
 const datasourceOptions: DataSourceSettings<TwinMakerDataSourceOptions, TwinMakerSecureJsonData> = {
   id: 0,
@@ -26,7 +25,6 @@ const datasourceOptions: DataSourceSettings<TwinMakerDataSourceOptions, TwinMake
   withCredentials: false,
   secureJsonFields: {},
 };
-const originalFormFeatureToggleValue = config.featureToggles.awsDatasourcesNewFormStyling;
 const workspacesMock = jest.fn(() => Promise.resolve([{ value: 'test1', label: 'test1' }]));
 
 jest.mock('common/datasourceSrv', () => ({
@@ -50,62 +48,38 @@ const resetWindow = () => {
     settings: {},
   };
 };
-const cleanup = () => {
-  config.featureToggles.awsDatasourcesNewFormStyling = originalFormFeatureToggleValue;
-};
 
 describe('ConfigEditor', () => {
   beforeEach(() => resetWindow());
-  function run() {
-    it('should display an error if the datasource is not saved', async () => {
-      const { rerender, user } = setup();
-      const rerenderOptions = {
-        ...datasourceOptions,
-        jsonData: {
-          assumeRoleArn: 'test_2',
-        },
-      };
-      rerender(<ConfigEditor options={rerenderOptions} onOptionsChange={() => {}} />);
-      const dropdown = screen.getByText('Select a workspace');
-      await user.click(dropdown);
-      const error = await screen.findByText('Save the datasource first to load workspaces');
-      expect(error).toBeInTheDocument();
-      expect(workspacesMock).not.toHaveBeenCalled();
-    });
-    it('should remove the error when the datasource is saved', async () => {
-      const { rerender, user } = setup();
-      const rerenderOptions = {
-        ...datasourceOptions,
-        jsonData: {
-          assumeRoleArn: 'test_2',
-        },
-      };
-      rerender(<ConfigEditor options={rerenderOptions} onOptionsChange={() => {}} />);
-      const dropdown = screen.getByText('Select a workspace');
-      await user.click(dropdown);
-      const error = await screen.findByText('Save the datasource first to load workspaces');
-      expect(error).toBeInTheDocument();
-      rerender(<ConfigEditor options={{ ...rerenderOptions, version: 2 }} onOptionsChange={() => {}} />);
-      waitFor(() => expect(error).not.toBeInTheDocument());
-    });
-  }
-
-  describe('Loading Workspaces with awsDatasourcesNewFormStyling feature toggle disabled', () => {
-    beforeAll(() => {
-      config.featureToggles.awsDatasourcesNewFormStyling = false;
-    });
-    afterAll(() => {
-      cleanup();
-    });
-    run();
+  it('should display an error if the datasource is not saved', async () => {
+    const { rerender, user } = setup();
+    const rerenderOptions = {
+      ...datasourceOptions,
+      jsonData: {
+        assumeRoleArn: 'test_2',
+      },
+    };
+    rerender(<ConfigEditor options={rerenderOptions} onOptionsChange={() => {}} />);
+    const dropdown = screen.getByText('Select a workspace');
+    await user.click(dropdown);
+    const error = await screen.findByText('Save the datasource first to load workspaces');
+    expect(error).toBeInTheDocument();
+    expect(workspacesMock).not.toHaveBeenCalled();
   });
-  describe('Loading Workspaces with awsDatasourcesNewFormStyling feature toggle enabled', () => {
-    beforeAll(() => {
-      config.featureToggles.awsDatasourcesNewFormStyling = true;
-    });
-    afterAll(() => {
-      cleanup();
-    });
-    run();
+  it('should remove the error when the datasource is saved', async () => {
+    const { rerender, user } = setup();
+    const rerenderOptions = {
+      ...datasourceOptions,
+      jsonData: {
+        assumeRoleArn: 'test_2',
+      },
+    };
+    rerender(<ConfigEditor options={rerenderOptions} onOptionsChange={() => {}} />);
+    const dropdown = screen.getByText('Select a workspace');
+    await user.click(dropdown);
+    const error = await screen.findByText('Save the datasource first to load workspaces');
+    expect(error).toBeInTheDocument();
+    rerender(<ConfigEditor options={{ ...rerenderOptions, version: 2 }} onOptionsChange={() => {}} />);
+    waitFor(() => expect(error).not.toBeInTheDocument());
   });
 });

--- a/src/datasource/components/ConfigEditor.tsx
+++ b/src/datasource/components/ConfigEditor.tsx
@@ -1,14 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { onUpdateDatasourceJsonDataOption, SelectableValue, updateDatasourcePluginJsonDataOption } from '@grafana/data';
 import { ConnectionConfig, ConnectionConfigProps, Divider } from '@grafana/aws-sdk';
-import { FieldSet, InlineField, InlineFieldRow, Select, Input, Alert, Checkbox, Field, Switch } from '@grafana/ui';
+import { Select, Input, Alert, Field, Switch } from '@grafana/ui';
 import { standardRegions } from '../regions';
 import { TwinMakerDataSourceOptions, TwinMakerSecureJsonData } from '../types';
 import { getTwinMakerDatasource } from 'common/datasourceSrv';
 import { getSelectionInfo } from 'common/info/info';
 import { SelectableQueryResults } from 'common/info/types';
 import { useEffectOnce } from 'react-use';
-import { config } from '@grafana/runtime';
 import { ConfigSection } from '@grafana/experimental';
 
 type Props = ConnectionConfigProps<TwinMakerDataSourceOptions, TwinMakerSecureJsonData>;
@@ -20,8 +19,6 @@ export function ConfigEditor(props: Props) {
   const [workspacesError, setWorkspacesError] = useState('');
   const [isLoadingWorkspaces, setLoadingWorkspaces] = useState(false);
   const [saved, setSaved] = useState(!!props.options.version && props.options.version > 1);
-
-  const newFormStylingEnabled = config.featureToggles.awsDatasourcesNewFormStyling;
 
   useEffectOnce(() => {
     // Default to 'us-east-1'
@@ -92,7 +89,7 @@ export function ConfigEditor(props: Props) {
 
   return (
     <div className="width-30">
-      <ConnectionConfig {...props} standardRegions={standardRegions} newFormStylingEnabled={newFormStylingEnabled} />
+      <ConnectionConfig {...props} standardRegions={standardRegions} />
       {!props.options.jsonData.assumeRoleArn && (
         <Alert title="Assume Role ARN" severity="error" style={{ width: 700 }}>
           Specify an IAM role to narrow the permission scope of this datasource. Follow the documentation{' '}
@@ -106,105 +103,52 @@ export function ConfigEditor(props: Props) {
           to create policies and a role with minimal permissions for your TwinMaker workspace.
         </Alert>
       )}
-      {newFormStylingEnabled ? (
-        <>
-          <Divider />
-          <ConfigSection title="Twinmaker Settings" data-testid="twinmaker-settings">
-            <Field label="Workspace" invalid={!!workspacesError} error={workspacesError}>
-              <Select
-                menuPlacement="top"
-                menuShouldPortal={true}
-                value={workspacesSelection.current}
-                options={workspacesSelection.options}
-                className="width-30"
-                onChange={onWorkspaceChange}
-                isLoading={isLoadingWorkspaces}
-                allowCustomValue={true}
-                onCreateOption={onUnknownWorkspaceChange}
-                formatCreateLabel={(v) => `WorkspaceID: ${v}`}
-                isClearable={true}
-                placeholder="Select a workspace"
-                noOptionsMessage="No workspaces found"
-                onOpenMenu={onOpenHandler}
-                onCloseMenu={() => setIsWorkspacesMenuOpen(false)}
-                isOpen={isWorkspacesMenuOpen}
-                invalid={!!workspacesError}
-              />
-            </Field>
-            <Field htmlFor="alarmConfigChecked" label="Define write permissions for Alarm Configuration Panel">
-              <Switch
-                id="alarmConfigChecked"
-                value={alarmConfigChecked}
-                onChange={(e) => onAlarmCheckChange(e.currentTarget.checked)}
-              />
-            </Field>
-
-            {alarmConfigChecked && (
-              <Field
-                htmlFor="assumeRoleArnWriter"
-                label="Assume Role ARN Write"
-                description="Specify the ARN of a role to assume when writing property values in IoT TwinMaker"
-              >
-                <Input
-                  id="assumeRoleArnWriter"
-                  placeholder="arn:aws:iam:*"
-                  value={props.options.jsonData.assumeRoleArnWriter || ''}
-                  onChange={onUpdateDatasourceJsonDataOption(props, 'assumeRoleArnWriter')}
-                />
-              </Field>
-            )}
-          </ConfigSection>
-        </>
-      ) : (
-        <FieldSet label={'TwinMaker settings'} data-testid="twinmaker-settings">
-          <InlineFieldRow>
-            <InlineField label="Workspace" labelWidth={28} invalid={!!workspacesError} error={workspacesError}>
-              <Select
-                menuPlacement="top"
-                menuShouldPortal={true}
-                value={workspacesSelection.current}
-                options={workspacesSelection.options}
-                className="width-30"
-                onChange={onWorkspaceChange}
-                isLoading={isLoadingWorkspaces}
-                allowCustomValue={true}
-                onCreateOption={onUnknownWorkspaceChange}
-                formatCreateLabel={(v) => `WorkspaceID: ${v}`}
-                isClearable={true}
-                disabled={workspaces?.length === 0}
-                placeholder="Select a workspace"
-                noOptionsMessage="No workspaces found"
-                onOpenMenu={onOpenHandler}
-                onCloseMenu={() => setIsWorkspacesMenuOpen(false)}
-                isOpen={isWorkspacesMenuOpen}
-                invalid={!!workspacesError}
-              />
-            </InlineField>
-          </InlineFieldRow>
-          <Checkbox
-            label={'Define write permissions for Alarm Configuration Panel'}
+      <Divider />
+      <ConfigSection title="Twinmaker Settings" data-testid="twinmaker-settings">
+        <Field label="Workspace" invalid={!!workspacesError} error={workspacesError}>
+          <Select
+            menuPlacement="top"
+            menuShouldPortal={true}
+            value={workspacesSelection.current}
+            options={workspacesSelection.options}
+            className="width-30"
+            onChange={onWorkspaceChange}
+            isLoading={isLoadingWorkspaces}
+            allowCustomValue={true}
+            onCreateOption={onUnknownWorkspaceChange}
+            formatCreateLabel={(v) => `WorkspaceID: ${v}`}
+            isClearable={true}
+            placeholder="Select a workspace"
+            noOptionsMessage="No workspaces found"
+            onOpenMenu={onOpenHandler}
+            onCloseMenu={() => setIsWorkspacesMenuOpen(false)}
+            isOpen={isWorkspacesMenuOpen}
+            invalid={!!workspacesError}
+          />
+        </Field>
+        <Field htmlFor="alarmConfigChecked" label="Define write permissions for Alarm Configuration Panel">
+          <Switch
+            id="alarmConfigChecked"
             value={alarmConfigChecked}
             onChange={(e) => onAlarmCheckChange(e.currentTarget.checked)}
           />
-          {alarmConfigChecked && (
-            <InlineFieldRow>
-              <InlineField
-                label="Assume Role ARN Write"
-                labelWidth={28}
-                tooltip="Specify the ARN of a role to assume when writing property values in IoT TwinMaker"
-              >
-                <Input
-                  aria-label="Assume Role ARN Write"
-                  className="width-30"
-                  placeholder="arn:aws:iam:*"
-                  value={props.options.jsonData.assumeRoleArnWriter || ''}
-                  onChange={onUpdateDatasourceJsonDataOption(props, 'assumeRoleArnWriter')}
-                />
-              </InlineField>
-            </InlineFieldRow>
-          )}
-        </FieldSet>
-      )}
+        </Field>
+
+        {alarmConfigChecked && (
+          <Field
+            htmlFor="assumeRoleArnWriter"
+            label="Assume Role ARN Write"
+            description="Specify the ARN of a role to assume when writing property values in IoT TwinMaker"
+          >
+            <Input
+              id="assumeRoleArnWriter"
+              placeholder="arn:aws:iam:*"
+              value={props.options.jsonData.assumeRoleArnWriter || ''}
+              onChange={onUpdateDatasourceJsonDataOption(props, 'assumeRoleArnWriter')}
+            />
+          </Field>
+        )}
+      </ConfigSection>
     </div>
   );
 }

--- a/src/datasource/components/FilterQueryEditor.tsx
+++ b/src/datasource/components/FilterQueryEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button, InlineField, InlineFieldRow, Select } from '@grafana/ui';
+import { Button, Select } from '@grafana/ui';
 import { DEFAULT_PROPERTY_FILTER_OPERATOR, TwinMakerFilterValue, TwinMakerPropertyFilter } from 'common/manager';
-import { editorFieldStyles, firstLabelWidth } from '.';
+import { editorFieldStyles } from '.';
 import { BlurTextInput } from './BlurTextInput';
 import { SelectableValue } from '@grafana/data';
 import { EditorField, EditorFieldGroup } from '@grafana/experimental';
@@ -13,7 +13,6 @@ export interface FilterQueryEditorProps {
   onChange: (index: number, filter?: TwinMakerPropertyFilter, isTabularCondition?: boolean) => void;
   onAdd: () => void;
   isTabularCondition?: boolean;
-  newFormStylingEnabled?: boolean;
 }
 
 export default function FilterQueryEditor(props: FilterQueryEditorProps) {
@@ -63,7 +62,7 @@ export default function FilterQueryEditor(props: FilterQueryEditorProps) {
     return '';
   };
 
-  return props.newFormStylingEnabled ? (
+  return (
     <EditorFieldGroup>
       {filters.map((f, index) => (
         <EditorField
@@ -130,56 +129,6 @@ export default function FilterQueryEditor(props: FilterQueryEditorProps) {
         </EditorField>
       ))}
     </EditorFieldGroup>
-  ) : (
-    <InlineFieldRow>
-      {filters.map((f, index) => (
-        <InlineField
-          key={`${index}/${f.name}`}
-          label={'Filter'}
-          grow={true}
-          labelWidth={firstLabelWidth}
-          tooltip="Enter expressions to filter property values"
-        >
-          <>
-            <Select
-              menuShouldPortal={true}
-              options={properties}
-              value={properties.find((v) => v.value === f.name)}
-              onChange={(v) => onNameChange(v, index)}
-              placeholder="Select a property"
-              isClearable={false}
-              width={40}
-            />
-            <BlurTextInput
-              width={14}
-              value={f.op ?? DEFAULT_PROPERTY_FILTER_OPERATOR}
-              onChange={(v) => {
-                if (v) {
-                  onOpChange(v, index);
-                }
-              }}
-              placeholder={DEFAULT_PROPERTY_FILTER_OPERATOR}
-            />
-            <BlurTextInput
-              value={filterValueToString(filters[index].value)}
-              onChange={(v) => {
-                if (v) {
-                  onValueChange(v, index);
-                }
-              }}
-              placeholder="value"
-              width={40}
-            />
-            <Button
-              icon="trash-alt"
-              variant="secondary"
-              onClick={() => onChange(index, undefined, isTabularCondition)} // Do not send event
-            />
-            {index === filters.length - 1 && <Button icon="plus-circle" variant="secondary" onClick={props.onAdd} />}
-          </>
-        </InlineField>
-      ))}
-    </InlineFieldRow>
   );
 }
 function isFilterEmpty(filter: TwinMakerPropertyFilter) {

--- a/src/datasource/components/OrderByEditor.tsx
+++ b/src/datasource/components/OrderByEditor.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Button, InlineField, InlineFieldRow, Select } from '@grafana/ui';
+import { Button, Select } from '@grafana/ui';
 import { TwinMakerOrderBy, TwinMakerResultOrder } from 'common/manager';
-import { firstLabelWidth } from '.';
 import { SelectableValue } from '@grafana/data';
 import { twinMakerOrderOptions } from 'datasource/queryInfo';
 import { EditorField, EditorFieldGroup } from '@grafana/experimental';
@@ -12,7 +11,6 @@ export interface OrderByEditorProps {
   properties: Array<SelectableValue<string>>;
   onChange: (index: number, orderBy?: TwinMakerOrderBy) => void;
   onAdd: () => void;
-  newFormStylingEnabled?: boolean;
 }
 
 export default function OrderByEditor(props: OrderByEditorProps) {
@@ -27,102 +25,61 @@ export default function OrderByEditor(props: OrderByEditorProps) {
   };
 
   return (
-    <>
-      {props.newFormStylingEnabled ? (
-        <EditorFieldGroup>
-          {orderBy.map((o, index) => (
-            <EditorField
-              key={`${index}/${o.propertyName}`}
-              label="Order By"
-              tooltip="enter the order of property values"
-              htmlFor="order-by"
-            >
-              <div className={css({ display: 'flex' })}>
-                <Select
-                  id="order-by"
-                  aria-label="order by property"
-                  menuShouldPortal={true}
-                  options={properties}
-                  value={properties.find((v) => v.value === o.propertyName)}
-                  onChange={(v) => onNameChange(v, index)}
-                  placeholder="Select a property"
-                  isClearable={false}
-                  width={25}
-                />
-                <Select
-                  aria-label="select order"
-                  menuShouldPortal={true}
-                  options={twinMakerOrderOptions}
-                  value={twinMakerOrderOptions.find((v) => v.value === o.order)}
-                  onChange={(v) => onOrderChange(v, index)}
-                  placeholder="default"
-                  isClearable={false}
-                  width={25}
-                />
-                <Button
-                  data-testid="query-builder-filters-remove-button"
-                  icon="trash-alt"
-                  variant="destructive"
-                  size="sm"
-                  className={btnStyle}
-                  onClick={() => onChange(index)}
-                />
+    <EditorFieldGroup>
+      {orderBy.map((o, index) => (
+        <EditorField
+          key={`${index}/${o.propertyName}`}
+          label="Order By"
+          tooltip="enter the order of property values"
+          htmlFor="order-by"
+        >
+          <div className={css({ display: 'flex' })}>
+            <Select
+              id="order-by"
+              aria-label="order by property"
+              menuShouldPortal={true}
+              options={properties}
+              value={properties.find((v) => v.value === o.propertyName)}
+              onChange={(v) => onNameChange(v, index)}
+              placeholder="Select a property"
+              isClearable={false}
+              width={25}
+            />
+            <Select
+              aria-label="select order"
+              menuShouldPortal={true}
+              options={twinMakerOrderOptions}
+              value={twinMakerOrderOptions.find((v) => v.value === o.order)}
+              onChange={(v) => onOrderChange(v, index)}
+              placeholder="default"
+              isClearable={false}
+              width={25}
+            />
+            <Button
+              data-testid="query-builder-filters-remove-button"
+              icon="trash-alt"
+              variant="destructive"
+              size="sm"
+              className={btnStyle}
+              onClick={() => onChange(index)}
+            />
 
-                {index === orderBy.length - 1 && (
-                  <Button
-                    data-testid="query-builder-filters-add-button"
-                    icon="plus-circle"
-                    variant="secondary"
-                    size="sm"
-                    className={btnStyle}
-                    onClick={props.onAdd}
-                  >
-                    Add
-                  </Button>
-                )}
-              </div>
-            </EditorField>
-          ))}
-        </EditorFieldGroup>
-      ) : (
-        <InlineFieldRow>
-          {orderBy.map((o, index) => (
-            <InlineField
-              key={`${index}/${o.propertyName}`}
-              label={'Order By'}
-              grow={true}
-              labelWidth={firstLabelWidth}
-              tooltip="enter the order of property values"
-            >
-              <>
-                <Select
-                  menuShouldPortal={true}
-                  options={properties}
-                  value={properties.find((v) => v.value === o.propertyName)}
-                  onChange={(v) => onNameChange(v, index)}
-                  placeholder="Select a property"
-                  isClearable={false}
-                  width={40}
-                />
-                <Select
-                  menuShouldPortal={true}
-                  options={twinMakerOrderOptions}
-                  value={twinMakerOrderOptions.find((v) => v.value === o.order)}
-                  onChange={(v) => onOrderChange(v, index)}
-                  placeholder="default"
-                  isClearable={false}
-                  width={40}
-                />
-                <Button icon="trash-alt" variant="secondary" onClick={() => onChange(index)} />
-                {index === orderBy.length - 1 && (
-                  <Button icon="plus-circle" variant="secondary" onClick={props.onAdd} />
-                )}
-              </>
-            </InlineField>
-          ))}
-        </InlineFieldRow>
-      )}
-    </>
+            {index === orderBy.length - 1 && (
+              <Button
+                data-testid="query-builder-filters-add-button"
+                icon="plus-circle"
+                variant="secondary"
+                size="sm"
+                className={btnStyle}
+                onClick={props.onAdd}
+              >
+                Add
+              </Button>
+            )}
+          </div>
+        </EditorField>
+      ))}
+    </EditorFieldGroup>
   );
 }
 

--- a/src/datasource/components/QueryEditor.test.tsx
+++ b/src/datasource/components/QueryEditor.test.tsx
@@ -7,7 +7,6 @@ import { TwinMakerDataSourceOptions } from 'datasource/types';
 import { TwinMakerDataSource } from 'datasource/datasource';
 import { of } from 'rxjs';
 import userEvent from '@testing-library/user-event';
-import { config } from '@grafana/runtime';
 import { SelectableComponentInfo } from 'common/info/types';
 const instanceSettings: DataSourceInstanceSettings<TwinMakerDataSourceOptions> = {
   id: 0,
@@ -23,10 +22,6 @@ const instanceSettings: DataSourceInstanceSettings<TwinMakerDataSourceOptions> =
   readOnly: false,
   withCredentials: false,
   meta: {} as any,
-};
-const originalFormFeatureToggleValue = config.featureToggles.awsDatasourcesNewFormStyling;
-const cleanup = () => {
-  config.featureToggles.awsDatasourcesNewFormStyling = originalFormFeatureToggleValue;
 };
 
 Promise.resolve([{ value: 'test1', label: 'test1' }]);
@@ -69,11 +64,6 @@ jest.mock('@grafana/runtime', () => ({
     getVariables: () => [],
     replace: (v: string) => v,
   }),
-  config: {
-    featureToggles: {
-      awsDatasourcesNewFormStyling: true,
-    },
-  },
 }));
 const getDatasource = (grafanaLive: boolean) => {
   const ds = new TwinMakerDataSource(instanceSettings);
@@ -88,127 +78,80 @@ const getDefaultProps = (grafanaLive: boolean) => ({
 });
 
 describe('QueryEditor', () => {
-  function run() {
-    it.each([
-      [TwinMakerQueryType.GetAlarms, ['Filter', 'Max. Alarms', 'Interval', 'Stream'], {}],
-      [TwinMakerQueryType.ListEntities, ['Component Type'], { isStreaming: true }],
-      [TwinMakerQueryType.GetEntity, ['Entity'], {}],
+  it.each([
+    [TwinMakerQueryType.GetAlarms, ['Filter', 'Max. Alarms', 'Interval', 'Stream'], {}],
+    [TwinMakerQueryType.ListEntities, ['Component Type'], { isStreaming: true }],
+    [TwinMakerQueryType.GetEntity, ['Entity'], {}],
 
-      [
-        TwinMakerQueryType.GetPropertyValue,
-        ['Entity', 'Component Name', 'Selected Properties', 'Filter', 'Order By'],
-        { isStreaming: true, componentName: 'mockEntity', entityId: 'mockEntity', propertyGroupName: 'propGroup1' },
-      ],
-      [
-        TwinMakerQueryType.EntityHistory,
-        ['Entity', 'Component Name', 'Selected Properties', 'Filter', 'Interval', 'Stream', 'Order'],
-        {},
-      ],
-      [
-        TwinMakerQueryType.ComponentHistory,
-        ['Component Type', 'Selected Properties', 'Filter', 'Interval', 'Stream', 'Order'],
-        {},
-      ],
-    ])(
-      'Renders all necessary fields when Twinmaker Query Type is %s and grafanaLive enabled',
-      async (type, expected, queryOptions) => {
-        const defaultProps = getDefaultProps(true);
-        const props = {
-          ...defaultProps,
-          query: {
-            ...defaultProps.query,
-            ...queryOptions,
-            queryType: type,
-          },
-        };
-        render(<QueryEditor {...props} />);
-        waitFor(() => {
-          if (config.featureToggles.awsDatasourcesNewFormStyling) {
-            openFormatCollapse();
-          }
-        });
-
-        for (const field of expected) {
-          // if newFormStyling is enabled, the Format section is hidden under a Collapse
-          await waitFor(() => expect(screen.getByText(field)).toBeInTheDocument());
-        }
+    [
+      TwinMakerQueryType.GetPropertyValue,
+      ['Entity', 'Component Name', 'Selected Properties', 'Filter', 'Order By'],
+      { isStreaming: true, componentName: 'mockEntity', entityId: 'mockEntity', propertyGroupName: 'propGroup1' },
+    ],
+    [
+      TwinMakerQueryType.EntityHistory,
+      ['Entity', 'Component Name', 'Selected Properties', 'Filter', 'Interval', 'Stream', 'Order'],
+      {},
+    ],
+    [
+      TwinMakerQueryType.ComponentHistory,
+      ['Component Type', 'Selected Properties', 'Filter', 'Interval', 'Stream', 'Order'],
+      {},
+    ],
+  ])(
+    'Renders all necessary fields when Twinmaker Query Type is %s and grafanaLive enabled',
+    async (type, expected, queryOptions) => {
+      const defaultProps = getDefaultProps(true);
+      const props = {
+        ...defaultProps,
+        query: {
+          ...defaultProps.query,
+          ...queryOptions,
+          queryType: type,
+        },
+      };
+      render(<QueryEditor {...props} />);
+      waitFor(() => {
+        openFormatCollapse();
+      });
+      for (const field of expected) {
+        await waitFor(() => expect(screen.getByText(field)).toBeInTheDocument());
       }
-    );
-  }
-  describe('QueryEditor with awsDatasourcesNewFormStyling feature toggle disabled', () => {
-    beforeAll(() => {
-      config.featureToggles.awsDatasourcesNewFormStyling = false;
-    });
-    afterAll(() => {
-      cleanup();
-    });
-    run();
-  });
-  describe('QueryEditor with awsDatasourcesNewFormStyling feature toggle enabled', () => {
-    beforeAll(() => {
-      config.featureToggles.awsDatasourcesNewFormStyling = true;
-    });
-    afterAll(() => {
-      cleanup();
-    });
-    run();
-  });
-  function runGrafanaLiveDisabled() {
-    it.each([
-      [TwinMakerQueryType.GetAlarms, ['Filter', 'Max. Alarms'], {}],
-      [TwinMakerQueryType.ListEntities, ['Component Type'], { isStreaming: true }],
-      [TwinMakerQueryType.GetEntity, ['Entity'], {}],
+    }
+  );
+  it.each([
+    [TwinMakerQueryType.GetAlarms, ['Filter', 'Max. Alarms'], {}],
+    [TwinMakerQueryType.ListEntities, ['Component Type'], { isStreaming: true }],
+    [TwinMakerQueryType.GetEntity, ['Entity'], {}],
 
-      [
-        TwinMakerQueryType.GetPropertyValue,
-        ['Entity', 'Component Name', 'Selected Properties', 'Filter', 'Order By'],
-        { isStreaming: true, componentName: 'mockEntity', entityId: 'mockEntity', propertyGroupName: 'propGroup1' },
-      ],
-      [TwinMakerQueryType.EntityHistory, ['Entity', 'Component Name', 'Selected Properties', 'Filter', 'Order'], {}],
-      [TwinMakerQueryType.ComponentHistory, ['Component Type', 'Selected Properties', 'Filter', 'Order'], {}],
-    ])(
-      'Renders all necessary fields when Twinmaker Query Type is %s and grafanaLive disabled',
-      async (type, expected, queryOptions) => {
-        const defaultProps = getDefaultProps(false);
-        const props = {
-          ...defaultProps,
-          query: {
-            ...defaultProps.query,
-            ...queryOptions,
-            queryType: type,
-          },
-        };
-        render(<QueryEditor {...props} />);
-        waitFor(() => {
-          if (config.featureToggles.awsDatasourcesNewFormStyling) {
-            openFormatCollapse();
-          }
-        });
-        for (const field of expected) {
-          // if newFormStyling is enabled, the Format section is hidden under a Collapse
-          await waitFor(() => screen.getByText(field));
-        }
+    [
+      TwinMakerQueryType.GetPropertyValue,
+      ['Entity', 'Component Name', 'Selected Properties', 'Filter', 'Order By'],
+      { isStreaming: true, componentName: 'mockEntity', entityId: 'mockEntity', propertyGroupName: 'propGroup1' },
+    ],
+    [TwinMakerQueryType.EntityHistory, ['Entity', 'Component Name', 'Selected Properties', 'Filter', 'Order'], {}],
+    [TwinMakerQueryType.ComponentHistory, ['Component Type', 'Selected Properties', 'Filter', 'Order'], {}],
+  ])(
+    'Renders all necessary fields when Twinmaker Query Type is %s and grafanaLive disabled',
+    async (type, expected, queryOptions) => {
+      const defaultProps = getDefaultProps(false);
+      const props = {
+        ...defaultProps,
+        query: {
+          ...defaultProps.query,
+          ...queryOptions,
+          queryType: type,
+        },
+      };
+      render(<QueryEditor {...props} />);
+      waitFor(() => {
+        openFormatCollapse();
+      });
+      for (const field of expected) {
+        await waitFor(() => screen.getByText(field));
       }
-    );
-  }
-  describe('QueryEditor with awsDatasourcesNewFormStyling feature toggle disabled', () => {
-    beforeAll(() => {
-      config.featureToggles.awsDatasourcesNewFormStyling = false;
-    });
-    afterAll(() => {
-      cleanup();
-    });
-    runGrafanaLiveDisabled();
-  });
-  describe('QueryEditor with awsDatasourcesNewFormStyling feature toggle enabled', () => {
-    beforeAll(() => {
-      config.featureToggles.awsDatasourcesNewFormStyling = true;
-    });
-    afterAll(() => {
-      cleanup();
-    });
-    runGrafanaLiveDisabled();
-  });
+    }
+  );
 });
 async function openFormatCollapse() {
   const collapseLabel = await screen.queryByTestId('collapse-title');

--- a/src/datasource/components/QueryEditor.tsx
+++ b/src/datasource/components/QueryEditor.tsx
@@ -1,23 +1,11 @@
 import defaults from 'lodash/defaults';
 import React, { PureComponent } from 'react';
-import {
-  Alert,
-  FieldValidationMessage,
-  Icon,
-  InlineField,
-  InlineFieldRow,
-  InlineSwitch,
-  Input,
-  LinkButton,
-  MultiSelect,
-  Select,
-  Switch,
-} from '@grafana/ui';
+import { Alert, Icon, Input, LinkButton, MultiSelect, Select, Switch } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { TwinMakerDataSource } from '../datasource';
 import { defaultQuery, TwinMakerDataSourceOptions } from '../types';
 import { TwinMakerApiModel } from 'aws-iot-twinmaker-grafana-utils';
-import { changeQueryType, QueryTypeInfo, twinMakerOrderOptions, twinMakerQueryTypes } from 'datasource/queryInfo';
+import { changeQueryType, QueryTypeInfo, twinMakerQueryTypes } from 'datasource/queryInfo';
 import {
   WorkspaceSelectionInfo,
   SelectableComponentInfo,
@@ -44,7 +32,7 @@ import {
   DEFAULT_PROPERTY_FILTER_OPERATOR,
   TwinMakerOrderBy,
 } from 'common/manager';
-import { config, getTemplateSrv } from '@grafana/runtime';
+import { getTemplateSrv } from '@grafana/runtime';
 import { getVariableOptions } from 'common/variables';
 import FilterQueryEditor from './FilterQueryEditor';
 import { BlurTextInput } from './BlurTextInput';
@@ -68,7 +56,6 @@ interface State {
 }
 
 export class QueryEditor extends PureComponent<Props, State> {
-  newFormStylingEnabled?: boolean;
   panels: Array<SelectableValue<number>>;
 
   constructor(props: Props) {
@@ -77,7 +64,6 @@ export class QueryEditor extends PureComponent<Props, State> {
     this.state = {
       invalidInterval: false,
     };
-    this.newFormStylingEnabled = config.featureToggles.awsDatasourcesNewFormStyling;
   }
 
   componentDidMount() {
@@ -311,42 +297,22 @@ export class QueryEditor extends PureComponent<Props, State> {
   renderEntitySelector(query: TwinMakerQuery, isClearable: boolean) {
     const entity = getSelectionInfo(query.entityId, this.state.workspace?.entities, this.state.templateVars);
     return (
-      <>
-        {this.newFormStylingEnabled ? (
-          <EditorField label="Entity" className={editorFieldStyles} width={30} htmlFor="entity">
-            <Select
-              id="entity"
-              aria-label="Entity"
-              width={30}
-              menuShouldPortal={true}
-              value={entity.current}
-              options={entity.options}
-              onChange={this.onEntityIdChange}
-              isClearable={isClearable}
-              allowCustomValue={true}
-              onCreateOption={this.onEntityIdTextChange}
-              formatCreateLabel={(v) => `EntityID: ${v}`}
-              isLoading={this.state.workspaceLoading}
-            />
-          </EditorField>
-        ) : (
-          <InlineFieldRow key="entity-selector">
-            <InlineField label={'Entity'} grow={true} labelWidth={firstLabelWidth}>
-              <Select
-                menuShouldPortal={true}
-                value={entity.current}
-                options={entity.options}
-                onChange={this.onEntityIdChange}
-                isClearable={isClearable}
-                allowCustomValue={true}
-                onCreateOption={this.onEntityIdTextChange}
-                formatCreateLabel={(v) => `EntityID: ${v}`}
-                isLoading={this.state.workspaceLoading}
-              />
-            </InlineField>
-          </InlineFieldRow>
-        )}
-      </>
+      <EditorField label="Entity" className={editorFieldStyles} width={30} htmlFor="entity">
+        <Select
+          id="entity"
+          aria-label="Entity"
+          width={30}
+          menuShouldPortal={true}
+          value={entity.current}
+          options={entity.options}
+          onChange={this.onEntityIdChange}
+          isClearable={isClearable}
+          allowCustomValue={true}
+          onCreateOption={this.onEntityIdTextChange}
+          formatCreateLabel={(v) => `EntityID: ${v}`}
+          isLoading={this.state.workspaceLoading}
+        />
+      </EditorField>
     );
   }
 
@@ -366,44 +332,22 @@ export class QueryEditor extends PureComponent<Props, State> {
       }
     }
     return (
-      <>
-        {this.newFormStylingEnabled ? (
-          <EditorField label="Component Type" className={editorFieldStyles} width={20} htmlFor="component-type">
-            <Select
-              id="component-type"
-              aria-label="Component Type"
-              menuShouldPortal={true}
-              value={compType.current}
-              options={compType.options}
-              onChange={this.onComponentTypeIdChange}
-              isClearable={true}
-              isLoading={this.state.workspaceLoading}
-              allowCustomValue={true}
-              onCreateOption={this.onComponentTypeIdTextChange}
-              formatCreateLabel={(v) => `Component Type: ${v}`}
-              placeholder={placeholder}
-            />
-          </EditorField>
-        ) : (
-          <InlineFieldRow key="component-type">
-            <InlineField label={'Component Type'} grow={true} labelWidth={firstLabelWidth}>
-              <Select
-                menuShouldPortal={true}
-                value={compType.current}
-                options={compType.options}
-                onChange={this.onComponentTypeIdChange}
-                isClearable={true}
-                isLoading={this.state.workspaceLoading}
-                allowCustomValue={true}
-                onCreateOption={this.onComponentTypeIdTextChange}
-                formatCreateLabel={(v) => `Component Type: ${v}`}
-                placeholder={placeholder}
-              />
-            </InlineField>
-            {isStreaming && this.renderStreamingInputs(query)}
-          </InlineFieldRow>
-        )}
-      </>
+      <EditorField label="Component Type" className={editorFieldStyles} width={20} htmlFor="component-type">
+        <Select
+          id="component-type"
+          aria-label="Component Type"
+          menuShouldPortal={true}
+          value={compType.current}
+          options={compType.options}
+          onChange={this.onComponentTypeIdChange}
+          isClearable={true}
+          isLoading={this.state.workspaceLoading}
+          allowCustomValue={true}
+          onCreateOption={this.onComponentTypeIdTextChange}
+          formatCreateLabel={(v) => `Component Type: ${v}`}
+          placeholder={placeholder}
+        />
+      </EditorField>
     );
   }
 
@@ -414,42 +358,21 @@ export class QueryEditor extends PureComponent<Props, State> {
     isStreaming?: boolean
   ) {
     return (
-      <>
-        {this.newFormStylingEnabled ? (
-          <EditorField label="Component Name" width={15} className={editorFieldStyles} htmlFor="component-name">
-            <Select
-              id="component-name"
-              aria-label="Component Name"
-              menuShouldPortal={true}
-              value={compName.current}
-              options={compName.options}
-              onChange={this.onComponentNameChange}
-              isClearable={isClearable}
-              isLoading={this.state.workspaceLoading}
-              allowCustomValue={true}
-              onCreateOption={this.onComponentNameTextChange}
-              formatCreateLabel={(v) => `Component Name: ${v}`}
-            />
-          </EditorField>
-        ) : (
-          <InlineFieldRow>
-            <InlineField label="Component Name" grow={true} labelWidth={firstLabelWidth}>
-              <Select
-                menuShouldPortal={true}
-                value={compName.current}
-                options={compName.options}
-                onChange={this.onComponentNameChange}
-                isClearable={isClearable}
-                isLoading={this.state.workspaceLoading}
-                allowCustomValue={true}
-                onCreateOption={this.onComponentNameTextChange}
-                formatCreateLabel={(v) => `Component Name: ${v}`}
-              />
-            </InlineField>
-            {isStreaming && this.renderStreamingInputs(query)}
-          </InlineFieldRow>
-        )}
-      </>
+      <EditorField label="Component Name" width={15} className={editorFieldStyles} htmlFor="component-name">
+        <Select
+          id="component-name"
+          aria-label="Component Name"
+          menuShouldPortal={true}
+          value={compName.current}
+          options={compName.options}
+          onChange={this.onComponentNameChange}
+          isClearable={isClearable}
+          isLoading={this.state.workspaceLoading}
+          allowCustomValue={true}
+          onCreateOption={this.onComponentNameTextChange}
+          formatCreateLabel={(v) => `Component Name: ${v}`}
+        />
+      </EditorField>
     );
   }
 
@@ -475,34 +398,17 @@ export class QueryEditor extends PureComponent<Props, State> {
     const current = query.filter?.length ? query.filter[0].value.stringValue : undefined;
     const filter = getSelectionInfo(current, alarmStatuses);
     return (
-      <>
-        {this.newFormStylingEnabled ? (
-          <EditorField label="Filter" className={editorFieldStyles} width={20} htmlFor="filter">
-            <Select
-              id="filter"
-              aria-label="filter"
-              menuShouldPortal={true}
-              value={filter.current}
-              options={filter.options}
-              onChange={this.onAlarmFilterChange}
-              isClearable={isClearable}
-            />
-          </EditorField>
-        ) : (
-          <InlineFieldRow>
-            <InlineField label={'Filter'} grow={true} labelWidth={firstLabelWidth}>
-              <Select
-                menuShouldPortal={true}
-                value={filter.current}
-                options={filter.options}
-                onChange={this.onAlarmFilterChange}
-                isClearable={isClearable}
-              />
-            </InlineField>
-            {this.renderStreamingInputs(query)}
-          </InlineFieldRow>
-        )}
-      </>
+      <EditorField label="Filter" className={editorFieldStyles} width={20} htmlFor="filter">
+        <Select
+          id="filter"
+          aria-label="filter"
+          menuShouldPortal={true}
+          value={filter.current}
+          options={filter.options}
+          onChange={this.onAlarmFilterChange}
+          isClearable={isClearable}
+        />
+      </EditorField>
     );
   }
 
@@ -510,97 +416,52 @@ export class QueryEditor extends PureComponent<Props, State> {
     if (!this.props.datasource.grafanaLiveEnabled) {
       return null;
     }
-    // Fixing weird typing issue
-    const FVM = FieldValidationMessage as any;
     return (
       <>
-        {this.newFormStylingEnabled ? (
-          <>
-            <EditorField
-              label="Stream"
-              tooltip="Polling data in an interval"
-              error={this.state.invalidInterval && 'Interval must be at least 5s'}
-              width={10}
-            >
-              <Switch value={Boolean(query.isStreaming)} onChange={this.onToggleStream} />
-            </EditorField>
-            <EditorField label="Interval" width={5} htmlFor="interval" tooltip="Set an interval in seconds to stream data, min 5s, default 30s">
-              <BlurTextInput
-                id="interval"
-                placeholder="30"
-                value={query.intervalStreaming ?? ''}
-                onChange={this.onIntervalChange}
-                numeric={true}
-              />
-            </EditorField>
-          </>
-        ) : (
-          <>
-            <InlineField label="Stream" tooltip="Polling data in an interval">
-              <InlineSwitch value={Boolean(query.isStreaming)} onChange={this.onToggleStream} />
-            </InlineField>
-            <InlineField
-              label="Interval"
-              tooltip="Set an interval in seconds to stream data, min 5s, default 30s"
-              disabled={!query.isStreaming}
-              invalid={this.state.invalidInterval}
-            >
-              <>
-                <BlurTextInput
-                  width={8}
-                  placeholder="30"
-                  value={query.intervalStreaming ?? ''}
-                  onChange={this.onIntervalChange}
-                  numeric={true}
-                />
-                {this.state.invalidInterval && <FVM>Interval must be at least 5s</FVM>}
-              </>
-            </InlineField>
-          </>
-        )}
+        <EditorField
+          label="Stream"
+          tooltip="Polling data in an interval"
+          width={10}
+        >
+          <Switch value={Boolean(query.isStreaming)} onChange={this.onToggleStream} />
+        </EditorField>
+        <EditorField
+          label="Interval"
+          width={5}
+          htmlFor="interval"
+          tooltip="Set an interval in seconds to stream data, min 5s, default 30s"
+          error={this.state.invalidInterval && 'Interval must be at least 5s'}
+          invalid={this.state.invalidInterval}
+        >
+          <BlurTextInput
+            id="interval"
+            placeholder="30"
+            value={query.intervalStreaming ?? ''}
+            onChange={this.onIntervalChange}
+            numeric={true}
+          />
+        </EditorField>
       </>
     );
   }
 
   renderAlarmMaxResultsInput(query: TwinMakerQuery) {
     return (
-      <>
-        {this.newFormStylingEnabled ? (
-          <EditorField
-            label="Max. Alarms"
-            tooltip="Leave this field blank to return all results"
-            className={editorFieldStyles}
-            width={5}
-          >
-            <Input
-              className="width-5"
-              value={query.maxResults && query.maxResults > 0 ? query.maxResults : ''}
-              type="number"
-              onChange={this.onMaxResultsChange}
-              placeholder="50"
-              min="1"
-            />
-          </EditorField>
-        ) : (
-          <InlineFieldRow>
-            <InlineField
-              label={'Max. Alarms'}
-              grow={true}
-              labelWidth={firstLabelWidth}
-              tooltip="Leave this field blank to return all results"
-            >
-              <Input
-                className="width-15"
-                value={query.maxResults && query.maxResults > 0 ? query.maxResults : ''}
-                type="number"
-                onChange={this.onMaxResultsChange}
-                placeholder="50"
-                min="1"
-              />
-            </InlineField>
-          </InlineFieldRow>
-        )}
-      </>
+      <EditorField
+        label="Max. Alarms"
+        tooltip="Leave this field blank to return all results"
+        className={editorFieldStyles}
+        width={5}
+      >
+        <Input
+          className="width-5"
+          value={query.maxResults && query.maxResults > 0 ? query.maxResults : ''}
+          type="number"
+          onChange={this.onMaxResultsChange}
+          placeholder="50"
+          min="1"
+        />
+      </EditorField>
     );
   }
 
@@ -630,41 +491,21 @@ export class QueryEditor extends PureComponent<Props, State> {
   renderPropsSelector(query: TwinMakerQuery, propOpts?: Array<SelectableValue<string>>, isLoading?: boolean) {
     const properties = this.getPropertiesMultiSelectionInfo(query, propOpts);
     return (
-      <>
-        {this.newFormStylingEnabled ? (
-          <EditorField label="Selected Properties" className={editorFieldStyles} width={20} htmlFor="selected-props">
-            <MultiSelect
-              id="selected-props"
-              aria-label="Selected Properties"
-              menuShouldPortal={true}
-              value={properties.current}
-              options={properties.options}
-              onChange={this.onPropertiesSelected}
-              isLoading={isLoading}
-              allowCustomValue={true}
-              onCreateOption={this.onCustomPropertyAdded}
-              formatCreateLabel={(v) => `Property: ${v}`}
-              placeholder="Type or select properties"
-            />
-          </EditorField>
-        ) : (
-          <InlineFieldRow>
-            <InlineField label={'Selected Properties'} grow={true} labelWidth={firstLabelWidth}>
-              <MultiSelect
-                menuShouldPortal={true}
-                value={properties.current}
-                options={properties.options}
-                onChange={this.onPropertiesSelected}
-                isLoading={isLoading}
-                allowCustomValue={true}
-                onCreateOption={this.onCustomPropertyAdded}
-                formatCreateLabel={(v) => `Property: ${v}`}
-                placeholder="Type or select properties"
-              />
-            </InlineField>
-          </InlineFieldRow>
-        )}
-      </>
+      <EditorField label="Selected Properties" className={editorFieldStyles} width={20} htmlFor="selected-props">
+        <MultiSelect
+          id="selected-props"
+          aria-label="Selected Properties"
+          menuShouldPortal={true}
+          value={properties.current}
+          options={properties.options}
+          onChange={this.onPropertiesSelected}
+          isLoading={isLoading}
+          allowCustomValue={true}
+          onCreateOption={this.onCustomPropertyAdded}
+          formatCreateLabel={(v) => `Property: ${v}`}
+          placeholder="Type or select properties"
+        />
+      </EditorField>
     );
   }
 
@@ -731,7 +572,6 @@ export class QueryEditor extends PureComponent<Props, State> {
         onAdd={this.onAddFilter(isTabularCondition)}
         onChange={this.onFilterChanged}
         isTabularCondition={isTabularCondition}
-        newFormStylingEnabled={this.newFormStylingEnabled}
       />
     );
   }
@@ -788,7 +628,6 @@ export class QueryEditor extends PureComponent<Props, State> {
 
     return (
       <OrderByEditor
-        newFormStylingEnabled={this.newFormStylingEnabled}
         orderBy={orderBy}
         properties={properties.options}
         onAdd={this.onAddOrderBy}
@@ -812,41 +651,21 @@ export class QueryEditor extends PureComponent<Props, State> {
 
   renderPropGroupSelector(propertyGroupName: string | undefined, propGroups?: SelectablePropGroupsInfo[]) {
     return (
-      <>
-        {this.newFormStylingEnabled ? (
-          <EditorField label="Property Group" className={editorFieldStyles} width={20} htmlFor="propertyGroupName">
-            <Select
-              id="propertyGroupName"
-              aria-label="Property Group"
-              menuShouldPortal={true}
-              value={propertyGroupName}
-              options={propGroups}
-              onChange={this.onPropertyGroupChange}
-              isClearable={true}
-              isLoading={this.state.workspaceLoading}
-              allowCustomValue={true}
-              onCreateOption={this.onPropertyGroupTextChange}
-              formatCreateLabel={(v) => `Property Group: ${v}`}
-            />
-          </EditorField>
-        ) : (
-          <InlineFieldRow>
-            <InlineField label={'Property Group'} grow={true} labelWidth={firstLabelWidth}>
-              <Select
-                menuShouldPortal={true}
-                value={propertyGroupName}
-                options={propGroups}
-                onChange={this.onPropertyGroupChange}
-                isClearable={true}
-                isLoading={this.state.workspaceLoading}
-                allowCustomValue={true}
-                onCreateOption={this.onPropertyGroupTextChange}
-                formatCreateLabel={(v) => `Property Group: ${v}`}
-              />
-            </InlineField>
-          </InlineFieldRow>
-        )}
-      </>
+      <EditorField label="Property Group" className={editorFieldStyles} width={20} htmlFor="propertyGroupName">
+        <Select
+          id="propertyGroupName"
+          aria-label="Property Group"
+          menuShouldPortal={true}
+          value={propertyGroupName}
+          options={propGroups}
+          onChange={this.onPropertyGroupChange}
+          isClearable={true}
+          isLoading={this.state.workspaceLoading}
+          allowCustomValue={true}
+          onCreateOption={this.onPropertyGroupTextChange}
+          formatCreateLabel={(v) => `Property Group: ${v}`}
+        />
+      </EditorField>
     );
   }
 
@@ -865,77 +684,41 @@ export class QueryEditor extends PureComponent<Props, State> {
       const compName = getSelectionInfo(query.componentName, this.state.entity, this.state.templateVars);
       return (
         <>
-          {this.newFormStylingEnabled ? (
-            <>
+          <EditorRow>
+            <EditorField label="Panel" htmlFor="panel">
+              <Select
+                id="panel"
+                aria-label="Panel"
+                menuShouldPortal={true}
+                value={panelSel.current}
+                options={panelSel.options}
+                onChange={this.onPanelChange}
+                isClearable={true}
+                placeholder={`Select TwinMaker panel`}
+              />
+            </EditorField>
+            <EditorField label="Topic" htmlFor="topic">
+              <Select
+                id="topic"
+                aria-label="Topic"
+                menuShouldPortal={true}
+                value={topicSel.current}
+                options={topicSel.options}
+                onChange={this.onPanelTopicChange}
+                width={16}
+              />
+            </EditorField>
+          </EditorRow>
+          {panelSel.current?.showPartialQuery ||
+            (query.topic === TwinMakerPanelTopic.SelectedItem && (
               <EditorRow>
-                <EditorField label="Panel" htmlFor="panel">
-                  <Select
-                    id="panel"
-                    aria-label="Panel"
-                    menuShouldPortal={true}
-                    value={panelSel.current}
-                    options={panelSel.options}
-                    onChange={this.onPanelChange}
-                    isClearable={true}
-                    placeholder={`Select TwinMaker panel`}
-                  />
-                </EditorField>
-                <EditorField label="Topic" htmlFor="topic">
-                  <Select
-                    id="topic"
-                    aria-label="Topic"
-                    menuShouldPortal={true}
-                    value={topicSel.current}
-                    options={topicSel.options}
-                    onChange={this.onPanelTopicChange}
-                    width={16}
-                  />
-                </EditorField>
+                <EditorFieldGroup>
+                  {this.renderEntitySelector(query, true)}
+                  {this.renderComponentNameSelector(query, compName, true)}
+                  {this.renderPropsSelector(query, this.state.workspace?.properties, this.state.workspaceLoading)}
+                </EditorFieldGroup>
               </EditorRow>
-              {panelSel.current?.showPartialQuery ||
-                (query.topic === TwinMakerPanelTopic.SelectedItem && (
-                  <EditorRow>
-                    <EditorFieldGroup>
-                      {this.renderEntitySelector(query, true)}
-                      {this.renderComponentNameSelector(query, compName, true)}
-                      {this.renderPropsSelector(query, this.state.workspace?.properties, this.state.workspaceLoading)}
-                    </EditorFieldGroup>
-                  </EditorRow>
-                ))}
-            </>
-          ) : (
-            <>
-              <InlineFieldRow>
-                <InlineField label={'Panel'} labelWidth={firstLabelWidth} grow={true}>
-                  <Select
-                    menuShouldPortal={true}
-                    value={panelSel.current}
-                    options={panelSel.options}
-                    onChange={this.onPanelChange}
-                    isClearable={true}
-                    placeholder={`Select TwinMaker panel`}
-                  />
-                </InlineField>
-                <InlineField label={'Topic'}>
-                  <Select
-                    menuShouldPortal={true}
-                    value={topicSel.current}
-                    options={topicSel.options}
-                    onChange={this.onPanelTopicChange}
-                    width={16}
-                  />
-                </InlineField>
-              </InlineFieldRow>
-              {panelSel.current?.showPartialQuery ||
-                (query.topic === TwinMakerPanelTopic.SelectedItem && (
-                  <>
-                    {this.renderEntitySelector(query, true)}
-                    {this.renderComponentNameSelector(query, compName, true)}
-                    {this.renderPropsSelector(query, this.state.workspace?.properties, this.state.workspaceLoading)}
-                  </>
-                ))}
-            </>
-          )}
+            ))}
         </>
       );
     }
@@ -948,46 +731,35 @@ export class QueryEditor extends PureComponent<Props, State> {
       case TwinMakerQueryType.GetAlarms:
         return (
           <>
-            {this.newFormStylingEnabled ? (
-              <>
-                <EditorRow>
-                  <EditorFieldGroup>
-                    {this.renderAlarmFilterSelector(query, true)}
-                    {this.renderAlarmMaxResultsInput(query)}
-                  </EditorFieldGroup>
-                </EditorRow>
-                <EditorRow>
-                  <QueryOptions
-                    query={query}
-                    grafanaLiveEnabled={this.props.datasource.grafanaLiveEnabled}
-                    onOrderChange={this.onOrderChange}
-                    renderStreamingInputs={() => this.renderStreamingInputs(query)}
-                  />
-                </EditorRow>
-              </>
-            ) : (
-              <>
+            <EditorRow>
+              <EditorFieldGroup>
                 {this.renderAlarmFilterSelector(query, true)}
                 {this.renderAlarmMaxResultsInput(query)}
-              </>
-            )}
+              </EditorFieldGroup>
+            </EditorRow>
+            <EditorRow>
+              <QueryOptions
+                query={query}
+                grafanaLiveEnabled={this.props.datasource.grafanaLiveEnabled}
+                onOrderChange={this.onOrderChange}
+                renderStreamingInputs={() => this.renderStreamingInputs(query)}
+              />
+            </EditorRow>
           </>
         );
+
       case TwinMakerQueryType.ListEntities:
-        return this.newFormStylingEnabled ? (
+        return (
           <EditorRow>
             <EditorFieldGroup>{this.renderComponentTypeSelector(query, compType)}</EditorFieldGroup>
           </EditorRow>
-        ) : (
-          this.renderComponentTypeSelector(query, compType)
         );
+
       case TwinMakerQueryType.GetEntity:
-        return this.newFormStylingEnabled ? (
+        return (
           <EditorRow>
             <EditorFieldGroup>{this.renderEntitySelector(query, false)}</EditorFieldGroup>
           </EditorRow>
-        ) : (
-          this.renderEntitySelector(query, false)
         );
       case TwinMakerQueryType.GetPropertyValue:
         if (query.entityId) {
@@ -1004,7 +776,7 @@ export class QueryEditor extends PureComponent<Props, State> {
           } else {
             propOpts = resolvePropsFromComponentSel(compName, ComponentFieldName.props, entityInfo);
           }
-          return this.newFormStylingEnabled ? (
+          return (
             <>
               <EditorRow>
                 <EditorFieldGroup>
@@ -1019,22 +791,13 @@ export class QueryEditor extends PureComponent<Props, State> {
               {propGroup && <EditorRow>{this.renderPropsFilterSelector(query, propOpts, isAthenaConnector)}</EditorRow>}
               {propGroup && <EditorRow>{this.renderOrderBySelector(query, propOpts)}</EditorRow>}
             </>
-          ) : (
-            <>
-              {this.renderEntitySelector(query, true)}
-              {this.renderComponentNameSelector(query, compName, true)}
-              {isAthenaConnector && this.renderPropGroupSelector(query.propertyGroupName, propGroups)}
-              {(!isAthenaConnector || propGroup) && this.renderPropsSelector(query, propOpts)}
-              {propGroup && this.renderPropsFilterSelector(query, propOpts, isAthenaConnector)}
-              {propGroup && this.renderOrderBySelector(query, propOpts)}
-            </>
           );
         }
         return this.renderEntitySelector(query, true);
       case TwinMakerQueryType.EntityHistory: {
         const compName = getSelectionInfo(query.componentName, entityInfo, this.state.templateVars);
         const propOpts = resolvePropsFromComponentSel(compName, ComponentFieldName.timeSeries, entityInfo);
-        return this.newFormStylingEnabled ? (
+        return (
           <>
             <EditorRow>
               <EditorFieldGroup>
@@ -1053,18 +816,11 @@ export class QueryEditor extends PureComponent<Props, State> {
               />
             </EditorRow>
           </>
-        ) : (
-          <>
-            {this.renderEntitySelector(query, true)}
-            {this.renderComponentNameSelector(query, compName, true, true)}
-            {this.renderPropsSelector(query, propOpts)}
-            {this.renderPropsFilterSelector(query, propOpts)}
-          </>
         );
       }
       case TwinMakerQueryType.ComponentHistory: {
         const propOpts = compType.current?.timeSeries as SelectableQueryResults;
-        return this.newFormStylingEnabled ? (
+        return (
           <>
             <EditorRow>
               {this.renderComponentTypeSelector(query, compType, 'timeSeries', true)}
@@ -1079,12 +835,6 @@ export class QueryEditor extends PureComponent<Props, State> {
                 renderStreamingInputs={() => this.renderStreamingInputs(query)}
               />
             </EditorRow>
-          </>
-        ) : (
-          <>
-            {this.renderComponentTypeSelector(query, compType, 'timeSeries', true)}
-            {this.renderPropsSelector(query, propOpts)}
-            {this.renderPropsFilterSelector(query, propOpts)}
           </>
         );
       }
@@ -1109,42 +859,21 @@ export class QueryEditor extends PureComponent<Props, State> {
       </div>
     ) : undefined;
 
-    const sortable =
-      query.queryType === TwinMakerQueryType.ComponentHistory || query.queryType === TwinMakerQueryType.EntityHistory;
-
     return (
       <div>
-        {this.newFormStylingEnabled ? (
-          <EditorRows>
-            <EditorRow>
-              <EditorFieldGroup>
-                <EditorField
-                  label="Query Type"
-                  tooltip={queryTooltip}
-                  className={editorFieldStyles}
-                  width={30}
-                  htmlFor="query-type"
-                >
-                  <Select
-                    id="query-type"
-                    aria-label="Query Type"
-                    menuShouldPortal={true}
-                    options={twinMakerQueryTypes}
-                    value={currentQueryType}
-                    onChange={this.onQueryTypeChange}
-                    placeholder="Select query type"
-                    menuPlacement="bottom"
-                  />
-                </EditorField>
-              </EditorFieldGroup>
-            </EditorRow>
-            {this.renderQuery(query)}
-          </EditorRows>
-        ) : (
-          <>
-            <InlineFieldRow>
-              <InlineField label="Query Type" labelWidth={firstLabelWidth} grow={true} tooltip={queryTooltip}>
+        <EditorRows>
+          <EditorRow>
+            <EditorFieldGroup>
+              <EditorField
+                label="Query Type"
+                tooltip={queryTooltip}
+                className={editorFieldStyles}
+                width={30}
+                htmlFor="query-type"
+              >
                 <Select
+                  id="query-type"
+                  aria-label="Query Type"
                   menuShouldPortal={true}
                   options={twinMakerQueryTypes}
                   value={currentQueryType}
@@ -1152,24 +881,11 @@ export class QueryEditor extends PureComponent<Props, State> {
                   placeholder="Select query type"
                   menuPlacement="bottom"
                 />
-              </InlineField>
-              {sortable && (
-                <InlineField label="Order">
-                  <Select
-                    menuShouldPortal={true}
-                    options={twinMakerOrderOptions}
-                    value={twinMakerOrderOptions.find((v) => v.value === query.order)}
-                    onChange={this.onOrderChange}
-                    placeholder="default"
-                    isClearable
-                    width={12}
-                  />
-                </InlineField>
-              )}
-            </InlineFieldRow>
-            {this.renderQuery(query)}
-          </>
-        )}
+              </EditorField>
+            </EditorFieldGroup>
+          </EditorRow>
+          {this.renderQuery(query)}
+        </EditorRows>
       </div>
     );
   }

--- a/src/datasource/dashboards/twinmaker-main-dashboard.json
+++ b/src/datasource/dashboards/twinmaker-main-dashboard.json
@@ -221,7 +221,9 @@
           },
           "entityId": "${sel_entity}",
           "filter": [],
-          "properties": ["alarm_status"],
+          "properties": [
+            "alarm_status"
+          ],
           "queryType": "EntityHistory",
           "refId": "A"
         }
@@ -267,7 +269,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -382,7 +386,9 @@
             "uid": "${DS_AWS_IOT TWINMAKER}"
           },
           "entityId": "${sel_entity}",
-          "properties": ["Temperature"],
+          "properties": [
+            "Temperature"
+          ],
           "propertyDisplayNames": {},
           "queryType": "EntityHistory",
           "refId": "A"
@@ -413,7 +419,9 @@
             "uid": "${DS_AWS_IOT TWINMAKER}"
           },
           "filter": [],
-          "properties": ["alarm_status"],
+          "properties": [
+            "alarm_status"
+          ],
           "propertyDisplayNames": {},
           "queryType": "ComponentHistory",
           "refId": "A"

--- a/src/datasource/dashboards/twinmaker-main-dashboard.json
+++ b/src/datasource/dashboards/twinmaker-main-dashboard.json
@@ -221,9 +221,7 @@
           },
           "entityId": "${sel_entity}",
           "filter": [],
-          "properties": [
-            "alarm_status"
-          ],
+          "properties": ["alarm_status"],
           "queryType": "EntityHistory",
           "refId": "A"
         }
@@ -269,9 +267,7 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": [
-            "sum"
-          ],
+          "reducer": ["sum"],
           "show": false
         },
         "showHeader": true,
@@ -386,9 +382,7 @@
             "uid": "${DS_AWS_IOT TWINMAKER}"
           },
           "entityId": "${sel_entity}",
-          "properties": [
-            "Temperature"
-          ],
+          "properties": ["Temperature"],
           "propertyDisplayNames": {},
           "queryType": "EntityHistory",
           "refId": "A"
@@ -419,9 +413,7 @@
             "uid": "${DS_AWS_IOT TWINMAKER}"
           },
           "filter": [],
-          "properties": [
-            "alarm_status"
-          ],
+          "properties": ["alarm_status"],
           "propertyDisplayNames": {},
           "queryType": "ComponentHistory",
           "refId": "A"

--- a/src/panels/query-editor/QueryEditor.tsx
+++ b/src/panels/query-editor/QueryEditor.tsx
@@ -6,5 +6,9 @@ import { QueryBuilder } from 'aws-iot-twinmaker-grafana-utils';
 import { CustomScrollbar } from '@grafana/ui';
 
 export const QueryEditor = (props: QueryEditorPropsFromParent) => {
-  return <CustomScrollbar><QueryBuilder workspaceId={props.workspaceId} awsConfig={props.awsConfig} /></CustomScrollbar>;
+  return (
+    <CustomScrollbar>
+      <QueryBuilder workspaceId={props.workspaceId} awsConfig={props.awsConfig} />
+    </CustomScrollbar>
+  );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3966,10 +3966,10 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/aws-sdk@0.3.1":
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/@grafana/aws-sdk/-/aws-sdk-0.3.1.tgz"
-  integrity sha512-YwJhe89qhYmpKWcP4smI90f+AB7C70mYcASnczZ9jGevOt8I8T6rQwTlsMJIoDXYMqYTpOzqi2FYemu/knSCqQ==
+"@grafana/aws-sdk@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.4.0.tgz#bc5192c48b47ca0911ba2ac777923abd337d1074"
+  integrity sha512-42OBqjb0zgEy1jgteg8llkz55p0r0GZGYxzxfLXHpqGQwqkextUO+axlGjRuylKl50d+XArZEvUNj4JWRGp23w==
   dependencies:
     "@grafana/async-query-data" "0.1.4"
     "@grafana/experimental" "1.7.0"


### PR DESCRIPTION
Removes the newFormStyling feature toggle, making the new styling default. Part of grafana/oss-plugin-partnerships#692