### PR TITLE
Prepare release 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.16.0
+
+- Migrate to new form styling in config and query editors in [#289](https://github.com/grafana/grafana-iot-twinmaker-app/pull/289)
+- add nested plugin to app includes in [#288](https://github.com/grafana/grafana-iot-twinmaker-app/pull/288)
+- Remove relative path info from executable field in [#282](https://github.com/grafana/grafana-iot-twinmaker-app/pull/282)
+
 ## 1.15.0
 
   - Support for [Dynamic Scenes](https://docs.aws.amazon.com/iot-twinmaker/latest/guide/dynamic-scenes.html)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0
 
+- Use Grafana theme for config editor width in [#290](https://github.com/grafana/grafana-iot-twinmaker-app/pull/290)
 - Migrate to new form styling in config and query editors in [#289](https://github.com/grafana/grafana-iot-twinmaker-app/pull/289)
 - add nested plugin to app includes in [#288](https://github.com/grafana/grafana-iot-twinmaker-app/pull/288)
 - Remove relative path info from executable field in [#282](https://github.com/grafana/grafana-iot-twinmaker-app/pull/282)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-twinmaker-app",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Grafana IoT TwinMaker App Plugin",
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=4096' webpack -c webpack.config.ts --env production ",

--- a/src/datasource/components/ConfigEditor.tsx
+++ b/src/datasource/components/ConfigEditor.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { onUpdateDatasourceJsonDataOption, SelectableValue, updateDatasourcePluginJsonDataOption } from '@grafana/data';
+import {
+  GrafanaTheme2,
+  onUpdateDatasourceJsonDataOption,
+  SelectableValue,
+  updateDatasourcePluginJsonDataOption,
+} from '@grafana/data';
 import { ConnectionConfig, ConnectionConfigProps, Divider } from '@grafana/aws-sdk';
-import { Select, Input, Alert, Field, Switch } from '@grafana/ui';
+import { Select, Input, Alert, Field, Switch, useStyles2 } from '@grafana/ui';
 import { standardRegions } from '../regions';
 import { TwinMakerDataSourceOptions, TwinMakerSecureJsonData } from '../types';
 import { getTwinMakerDatasource } from 'common/datasourceSrv';
@@ -9,6 +14,7 @@ import { getSelectionInfo } from 'common/info/info';
 import { SelectableQueryResults } from 'common/info/types';
 import { useEffectOnce } from 'react-use';
 import { ConfigSection } from '@grafana/experimental';
+import { css } from '@emotion/css';
 
 type Props = ConnectionConfigProps<TwinMakerDataSourceOptions, TwinMakerSecureJsonData>;
 
@@ -87,8 +93,9 @@ export function ConfigEditor(props: Props) {
 
   const workspacesSelection = getSelectionInfo(props.options.jsonData.workspaceId, workspaces, undefined, true);
 
+  const styles = useStyles2(getStyles);
   return (
-    <div className="width-30">
+    <div className={styles.formStyles}>
       <ConnectionConfig {...props} standardRegions={standardRegions} />
       {!props.options.jsonData.assumeRoleArn && (
         <Alert title="Assume Role ARN" severity="error" style={{ width: 700 }}>
@@ -152,3 +159,9 @@ export function ConfigEditor(props: Props) {
     </div>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  formStyles: css({
+    maxWidth: theme.spacing(50),
+  }),
+});


### PR DESCRIPTION
I realized we weren't using Grafana theme for the Config editor width, so squeezing that in here too ('width-30' will be deprecated at some point)

## 1.16.0

- Use Grafana theme for config editor width in [#290](https://github.com/grafana/grafana-iot-twinmaker-app/pull/290)
- Migrate to new form styling in config and query editors in [#289](https://github.com/grafana/grafana-iot-twinmaker-app/pull/289)
- add nested plugin to app includes in [#288](https://github.com/grafana/grafana-iot-twinmaker-app/pull/288)
- Remove relative path info from executable field in [#282](https://github.com/grafana/grafana-iot-twinmaker-app/pull/282)
