### PR TITLE
Chore: Update plugin.json keywords

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -11,7 +11,7 @@
       "name": "AWS IoT TwinMaker",
       "url": "https://aws.amazon.com"
     },
-    "keywords": ["aws", "iot", "panel", "cloud provider", "twinmaker"],
+    "keywords": ["application", "aws", "amazon", "iot", "panel", "cloud provider", "twinmaker"],
     "logos": {
       "small": "img/AWS-IoT-TwinMaker.png",
       "large": "img/AWS-IoT-TwinMaker.png"


### PR DESCRIPTION
Update plugin.json keywords to include "amazon" + "application"

Related to https://github.com/grafana/oss-plugin-partnerships/issues/1055