### PR TITLE
Chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: '@iot-app-kit/*'
+      - dependency-name: '@aws-sdk/*'
+      - dependency-name: '@cloudscape-design/*'
     groups:
       all-node-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: 'gomod'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      all-go-dependencies:
+        patterns:
+          - '*'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      all-github-action-dependencies:
+        patterns:
+          - '*'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      all-node-dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a dependabot config to update dependencies on a weekly cadence. It'll group dependency updates according to the package ecosystem to reduce PR noise.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/oss-plugin-partnerships/issues/931

**Special notes for your reviewer**:
I've left the packages in the `@iot-app-kit`, `@aws-sdk`, and `@cloudscape-design` scopes to be ignored by dependabot so they will need to be manually updated. I believe these packages are updated by the twinmaker team as needed.