### PR TITLE
Dependabot config: Ignore react and react-dom major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
       - dependency-name: '@iot-app-kit/*'
       - dependency-name: '@aws-sdk/*'
       - dependency-name: '@cloudscape-design/*'
+      - dependency-name: 'react'
+      - update-types: ["version-update:semver-major"]
+      - dependency-name: 'react-dom'
+      - update-types: ["version-update:semver-major"]
     groups:
       all-node-dependencies:
         patterns:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:

I ran into issues when an update to react 19.0 was submitted in a dependabot PR. Grafana main runs on react@18, so there was a mismatch and subsequent errors. Not sure if there's a better way to do it than this, but we probably dont want to include major updates to react and react-dom in every dependabot PR. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
