### PR TITLE
Remove TwinmakerPanel query code

### DIFF
--- a/src/common/manager.ts
+++ b/src/common/manager.ts
@@ -75,24 +75,8 @@ export interface TwinMakerQuery extends DataQuery {
   propertyGroupName?: string;
 }
 
-export interface TwinMakerPanelQuery extends TwinMakerQuery {
-  queryType: TwinMakerQueryType.TwinMakerPanel;
-
-  panelId?: number;
-  topic?: TwinMakerPanelTopic;
-}
-
-export function isTwinMakerPanelQuery(query: DataQuery): query is TwinMakerPanelQuery {
-  return query?.queryType === TwinMakerQueryType.TwinMakerPanel;
-}
-
 /** Request without targets */
 export type BaseDataQueryOptions = Omit<DataQueryRequest, 'targets'>;
-
-export type TwinMakerPanelQueryRunner = (
-  query: TwinMakerPanelQuery,
-  options: BaseDataQueryOptions
-) => Observable<DataQueryResponse>;
 
 export enum TwinMakerPanelTopic {
   /** the selected item */
@@ -108,40 +92,7 @@ export enum TwinMakerPanelTopic {
   VisibleAnchors = 'visibleAnchors',
 }
 
-export interface TwinMakerPanelTopicInfo extends SelectableValue<TwinMakerPanelTopic> {
-  showPartialQuery?: boolean;
-}
-
-export const panelTopicInfo: TwinMakerPanelTopicInfo[] = [
-  {
-    value: TwinMakerPanelTopic.SelectedItem,
-    label: 'Selected item',
-    description: 'Show the selected target from a scene',
-    showPartialQuery: true,
-  },
-  {
-    value: TwinMakerPanelTopic.SelectedAlarm,
-    label: 'Selected alarm',
-    description: 'Show the selected target from a scene',
-    showPartialQuery: true,
-  },
-  {
-    value: TwinMakerPanelTopic.VisibleComponents,
-    label: 'Visible components (future)',
-    description: 'Show the selected target from a scene',
-  },
-  {
-    value: TwinMakerPanelTopic.VisibleAnchors,
-    label: 'Visible anchors (future)',
-    description: 'Show the selected target from a scene',
-  },
-];
-
 export interface TwinMakerPanelInstance {
-  /**
-   * Panel query execution
-   */
-  twinMakerPanelQueryRunner: TwinMakerPanelQueryRunner;
 
   /**
    * TODO?
@@ -152,20 +103,9 @@ export interface TwinMakerPanelInstance {
 
 /** Singleton controller for the whole dashboard.  Will manage layout and posting commands */
 export interface TwinMakerDashboardManager {
-  /** Execute a panel query  */
-  twinMakerPanelQueryRunner: TwinMakerPanelQueryRunner;
-
   /** Find the current   */
   listTwinMakerPanels: () => Array<SelectableValue<number>>;
-
-  /** Refresh any panels listening to the twinmaker panel for actions */
-  refresh: (panelId?: number) => void;
-
-  /**
-   * Get the supported query options
-   */
-  getQueryTopics: (panelId?: number) => TwinMakerPanelTopicInfo[];
-
+  
   /** Called when a scene panel initializes */
   registerTwinMakerPanel: (panelId: number, panel: TwinMakerPanelInstance) => void;
 

--- a/src/common/manager.ts
+++ b/src/common/manager.ts
@@ -1,6 +1,5 @@
-import { SelectableValue, DataQueryResponse, DataQueryRequest } from '@grafana/data';
+import { DataQueryRequest } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
-import { Observable } from 'rxjs';
 import { getSimpleTwinMakerDashboardManager } from './managerSimple';
 
 export enum TwinMakerQueryType {
@@ -91,9 +90,7 @@ export enum TwinMakerPanelTopic {
   /** anchors in view */
   VisibleAnchors = 'visibleAnchors',
 }
-
 export interface TwinMakerPanelInstance {
-
   /**
    * TODO?
    * callback when the dashboard manager discovers an event
@@ -103,9 +100,6 @@ export interface TwinMakerPanelInstance {
 
 /** Singleton controller for the whole dashboard.  Will manage layout and posting commands */
 export interface TwinMakerDashboardManager {
-  /** Find the current   */
-  listTwinMakerPanels: () => Array<SelectableValue<number>>;
-  
   /** Called when a scene panel initializes */
   registerTwinMakerPanel: (panelId: number, panel: TwinMakerPanelInstance) => void;
 

--- a/src/common/managerSimple.ts
+++ b/src/common/managerSimple.ts
@@ -1,40 +1,11 @@
-import { TWINMAKER_PANEL_TYPE_ID } from './constants';
-import { getCurrentDashboard } from './dashboard';
-import { ReplaySubject, of, mergeMap } from 'rxjs';
+import { ReplaySubject } from 'rxjs';
 import {
-  BaseDataQueryOptions,
   TwinMakerDashboardManager,
   TwinMakerPanelInstance,
-  TwinMakerPanelQuery,
-  panelTopicInfo,
-  isTwinMakerPanelQuery,
 } from './manager';
 
 export class SimpleTwinMakerDashboardManager implements TwinMakerDashboardManager {
   panels = new Map<number, ReplaySubject<TwinMakerPanelInstance>>();
-
-  /** A list of the scene viewer panels on the dashboard */
-  listTwinMakerPanels() {
-    const keep: Set<string> = new Set(Object.values(TWINMAKER_PANEL_TYPE_ID));
-    const dash = getCurrentDashboard();
-    // dashboard is not available in explore view
-    if (!dash) {
-      return [];
-    }
-    return dash.panels
-      .filter((p) => keep.has(p.type))
-      .map((p) => {
-        let label = p.title ?? `Panel: ${p.id}`;
-        if (p.options.sceneId) {
-          label += ` (${p.options.sceneId})`;
-        }
-        return {
-          value: p.id,
-          label,
-          imgUrl: `public/plugins/${p.type}/img/icon.svg`,
-        };
-      });
-  }
 
   /** Get access to scene info */
   private getTwinMakerPanelInstance(panelId: number) {

--- a/src/common/managerSimple.ts
+++ b/src/common/managerSimple.ts
@@ -36,31 +36,6 @@ export class SimpleTwinMakerDashboardManager implements TwinMakerDashboardManage
       });
   }
 
-  refresh(panelId?: number) {
-    console.log('refresh all panels pointing to: ', panelId);
-    getCurrentDashboard()?.panels.forEach((p) => {
-      if (p.targets) {
-        for (const q of p.targets) {
-          if (isTwinMakerPanelQuery(q) && (q.panelId === panelId || !panelId)) {
-            p.refresh();
-            break;
-          }
-        }
-      }
-    });
-  }
-
-  twinMakerPanelQueryRunner = (query: TwinMakerPanelQuery, options: BaseDataQueryOptions) => {
-    if (!query.panelId) {
-      return of({ error: { message: 'missing panel id' }, data: [] });
-    }
-    return this.getTwinMakerPanelInstance(query.panelId).pipe(
-      mergeMap((stream) => {
-        return stream.twinMakerPanelQueryRunner(query, options);
-      })
-    );
-  };
-
   /** Get access to scene info */
   private getTwinMakerPanelInstance(panelId: number) {
     let p = this.panels.get(panelId);
@@ -69,21 +44,6 @@ export class SimpleTwinMakerDashboardManager implements TwinMakerDashboardManage
       this.panels.set(panelId, p);
     }
     return p;
-  }
-
-  /**
-   * Get the supported query options
-   */
-  getQueryTopics(panelId?: number) {
-    if (!panelId) {
-      return panelTopicInfo;
-    }
-    // ??? some panels may have different support
-    const panel = getCurrentDashboard()?.panels.find((p) => p.id === panelId);
-    if (panel?.type === TWINMAKER_PANEL_TYPE_ID.LAYOUT) {
-      return panelTopicInfo;
-    }
-    return panelTopicInfo;
   }
 
   /** Called when a scene panel initializes */

--- a/src/datasource/queryInfo.ts
+++ b/src/datasource/queryInfo.ts
@@ -8,12 +8,6 @@ export interface QueryTypeInfo extends SelectableValue<TwinMakerQueryType> {
 }
 
 export const twinMakerQueryTypes: QueryTypeInfo[] = [
-  // {
-  //   label: 'TwinMaker panel state',
-  //   value: TwinMakerQueryType.TwinMakerPanel,
-  //   description: `Show data based on the state of another TwinMaker panel`,
-  //   defaultQuery: {},
-  // },
   {
     label: 'Get Property Value History by Entity',
     value: TwinMakerQueryType.EntityHistory,

--- a/src/hooks/usePanelRegistration.ts
+++ b/src/hooks/usePanelRegistration.ts
@@ -1,11 +1,9 @@
 import { useEffect } from 'react';
-import { throwError } from 'rxjs';
 import { getTwinMakerDashboardManager } from 'common/manager';
 
 export const usePanelRegistration = (id: number) => {
   useEffect(() => {
     getTwinMakerDashboardManager().registerTwinMakerPanel(id, {
-      twinMakerPanelQueryRunner: () => throwError(() => `not implemented yet (see twinmaker debug panel)`),
       onDashboardAction: (cmd) => {},
     });
     //unmount effect

--- a/src/panels/scene-viewer/ScenePanel.tsx
+++ b/src/panels/scene-viewer/ScenePanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Unsubscribable, throwError } from 'rxjs';
+import { Unsubscribable } from 'rxjs';
 import { PanelProps } from '@grafana/data';
 import { LoadingPlaceholder } from '@grafana/ui';
 

--- a/src/panels/scene-viewer/ScenePanel.tsx
+++ b/src/panels/scene-viewer/ScenePanel.tsx
@@ -19,12 +19,6 @@ export class ScenePanel extends React.Component<Props, ScenePanelState> {
 
   constructor(props: Props) {
     super(props);
-    getTwinMakerDashboardManager().registerTwinMakerPanel(this.props.id, {
-      twinMakerPanelQueryRunner: () => throwError(() => `not implemented yet (see twinmaker debug panel)`),
-      onDashboardAction: (cmd) => {
-        console.log('TODO! implement action sent from the manager???', cmd);
-      },
-    });
     this.state = {
       configured: false,
     };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:
This removes code related to something called Twinmaker Panel query. while migrating to scenes, I noticed that it was commented out in the query type options, so I removed it, and related functions, to make it easier to migrate. I also removed the `refresh` method from the dashboard manager, since that wasn't used anywhere either. 
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
