### PR TITLE
Add PDC support

### DIFF
--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 )
 
 type TwinMakerDataSourceSetting struct {
 	awsds.AWSDatasourceSettings
+	ProxyOptions        *proxy.Options
 	AssumeRoleARNWriter string `json:"assumeRoleArnWriter"`
 	WorkspaceID         string `json:"workspaceId"`
 	UID                 string `json:"uid"`

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -29,6 +29,11 @@ func NewTwinMakerInstance(ctx context.Context, s backend.DataSourceInstanceSetti
 	if err != nil {
 		return nil, err
 	}
+	proxyOptions, err := s.ProxyOptionsFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	settings.ProxyOptions = proxyOptions
 
 	return NewTwinMakerDatasource(ctx, settings), nil
 }

--- a/pkg/plugin/twinmaker/client.go
+++ b/pkg/plugin/twinmaker/client.go
@@ -51,7 +51,7 @@ func NewTwinMakerClient(ctx context.Context, settings models.TwinMakerDataSource
 	if err != nil {
 		return nil, err
 	}
-	transport, err := httpclient.GetTransport()
+	transport, err := httpclient.GetTransport(httpclient.Options{ProxyOptions: settings.ProxyOptions})
 	if err != nil {
 		return nil, err
 	}

--- a/src/datasource/components/ConfigEditor.tsx
+++ b/src/datasource/components/ConfigEditor.tsx
@@ -5,8 +5,9 @@ import {
   SelectableValue,
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { ConnectionConfig, ConnectionConfigProps, Divider } from '@grafana/aws-sdk';
-import { Select, Input, Alert, Field, Switch, useStyles2 } from '@grafana/ui';
+import { Select, Input, Alert, Field, SecureSocksProxySettings, Switch, useStyles2 } from '@grafana/ui';
 import { standardRegions } from '../regions';
 import { TwinMakerDataSourceOptions, TwinMakerSecureJsonData } from '../types';
 import { getTwinMakerDatasource } from 'common/datasourceSrv';
@@ -15,6 +16,7 @@ import { SelectableQueryResults } from 'common/info/types';
 import { useEffectOnce } from 'react-use';
 import { ConfigSection } from '@grafana/plugin-ui';
 import { css } from '@emotion/css';
+import { gte } from 'semver';
 
 type Props = ConnectionConfigProps<TwinMakerDataSourceOptions, TwinMakerSecureJsonData>;
 
@@ -109,6 +111,9 @@ export function ConfigEditor(props: Props) {
           </a>{' '}
           to create policies and a role with minimal permissions for your TwinMaker workspace.
         </Alert>
+      )}
+      {config.secureSocksDSProxyEnabled && gte(config.buildInfo.version, '10.0.0') && (
+        <SecureSocksProxySettings options={props.options} onOptionsChange={props.onOptionsChange} />
       )}
       <Divider />
       <ConfigSection title="Twinmaker Settings" data-testid="twinmaker-settings">


### PR DESCRIPTION
Fixes: https://github.com/grafana/oss-plugin-partnerships/issues/1220

[Instructions for testing PDC locally](https://wiki.grafana-ops.net/w/index.php/Engineering/Grafana/Data_Sources/API_servers/Testing_datasources_with_PDC_Locally).

New secure socks proxy setting added below the region selector in the config page

<img width="632" alt="Screenshot 2025-04-25 at 8 56 10 AM" src="https://github.com/user-attachments/assets/550a353f-cce7-4625-b6ec-73152d9468eb" />
