### PR TITLE
Prepare 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.0.1
+
+- Chore: add label to external contributions in [#358](https://github.com/grafana/grafana-iot-twinmaker-app/pull/358)
+- Migrate dashboard utils to Scenes in [#383](https://github.com/grafana/grafana-iot-twinmaker-app/pull/383)
+- Remove TwinmakerPanel query code in [#382](https://github.com/grafana/grafana-iot-twinmaker-app/pull/382)
+- Update pr-commands.yml in [#391](https://github.com/grafana/grafana-iot-twinmaker-app/pull/391)
+- Use vault to generate token in [#390](https://github.com/grafana/grafana-iot-twinmaker-app/pull/390)
+- Update github actions files in [#388](https://github.com/grafana/grafana-iot-twinmaker-app/pull/388)
+- Bump node dependencies in [#365](https://github.com/grafana/grafana-iot-twinmaker-app/pull/365), [#371](https://github.com/grafana/grafana-iot-twinmaker-app/pull/371), [#372](https://github.com/grafana/grafana-iot-twinmaker-app/pull/372), [#363](https://github.com/grafana/grafana-iot-twinmaker-app/pull/363), [#360](https://github.com/grafana/grafana-iot-twinmaker-app/pull/360), [#353](https://github.com/grafana/grafana-iot-twinmaker-app/pull/353)
+- Bump go dependencies in [#351](https://github.com/grafana/grafana-iot-twinmaker-app/pull/351), [#354](https://github.com/grafana/grafana-iot-twinmaker-app/pull/354), [#359](https://github.com/grafana/grafana-iot-twinmaker-app/pull/359), [#362](https://github.com/grafana/grafana-iot-twinmaker-app/pull/362), [#364](https://github.com/grafana/grafana-iot-twinmaker-app/pull/364), [#368](https://github.com/grafana/grafana-iot-twinmaker-app/pull/368), [#374](https://github.com/grafana/grafana-iot-twinmaker-app/pull/374)
 ## 2.0.0
 
 - Migrate to plugin-ui from grafana/experimental in [#344](https://github.com/grafana/grafana-iot-twinmaker-app/pull/344)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-iot-twinmaker-app",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Grafana IoT TwinMaker App Plugin",
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=4096' webpack -c ./webpack.config.ts --env production",


### PR DESCRIPTION
## 2.0.1

- Chore: add label to external contributions in [#358](https://github.com/grafana/grafana-iot-twinmaker-app/pull/358)
- Migrate dashboard utils to Scenes in [#383](https://github.com/grafana/grafana-iot-twinmaker-app/pull/383)
- Remove TwinmakerPanel query code in [#382](https://github.com/grafana/grafana-iot-twinmaker-app/pull/382)
- Update pr-commands.yml in [#391](https://github.com/grafana/grafana-iot-twinmaker-app/pull/391)
- Use vault to generate token in [#390](https://github.com/grafana/grafana-iot-twinmaker-app/pull/390)
- Update github actions files in [#388](https://github.com/grafana/grafana-iot-twinmaker-app/pull/388)
- Bump node dependencies in [#365](https://github.com/grafana/grafana-iot-twinmaker-app/pull/365), [#371](https://github.com/grafana/grafana-iot-twinmaker-app/pull/371), [#372](https://github.com/grafana/grafana-iot-twinmaker-app/pull/372), [#363](https://github.com/grafana/grafana-iot-twinmaker-app/pull/363), [#360](https://github.com/grafana/grafana-iot-twinmaker-app/pull/360), [#353](https://github.com/grafana/grafana-iot-twinmaker-app/pull/353)
- Bump go dependencies in [#351](https://github.com/grafana/grafana-iot-twinmaker-app/pull/351), [#354](https://github.com/grafana/grafana-iot-twinmaker-app/pull/354), [#359](https://github.com/grafana/grafana-iot-twinmaker-app/pull/359), [#362](https://github.com/grafana/grafana-iot-twinmaker-app/pull/362), [#364](https://github.com/grafana/grafana-iot-twinmaker-app/pull/364), [#368](https://github.com/grafana/grafana-iot-twinmaker-app/pull/368), [#374](https://github.com/grafana/grafana-iot-twinmaker-app/pull/374)