### PR TITLE
Update workflows and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,14 +1,16 @@
 ---
 name: Bug report
 about: Report a bug you found when using this plugin
-labels: ["datasource/TwinMaker", "type/bug"]
+labels: ['datasource/TwinMaker', 'type/bug']
 ---
 
 <!--
-Tip: record your screen and attach it as a gif to showcase the issue.
+Please use this template to create your bug report. By providing as much info as possible you help us understand the issue, reproduce it and resolve it for you quicker. Therefore, take a couple of extra minutes to make sure you have provided all info needed.
 
-- Use query inspector to troubleshoot issues: https://bit.ly/2XNF6YS
-- How to record and attach gif: https://bit.ly/2Mi8T6K
+PROTIP: record your screen and attach it as a gif to showcase the issue.
+
+- Use query inspector to troubleshoot issues: https://community.grafana.com/t/how-to-use-grafanas-query-inspector-to-troubleshoot-issues/2630
+- How to record and attach gif: https://community.grafana.com/t/proptip-record-gif-and-attach-to-bug-report-to-showcase-issue/31320
 -->
 
 **What happened**:
@@ -17,8 +19,27 @@ Tip: record your screen and attach it as a gif to showcase the issue.
 
 **How to reproduce it (as minimally and precisely as possible)**:
 
+<!--
+Example:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+**Screenshots**
+
+<!--
+If applicable, add screenshots to help explain your problem.
+-->
+
 **Anything else we need to know?**:
 
 **Environment**:
+
 - Grafana version:
 - Plugin version:
+- OS Grafana is installed on:
+- User OS & Browser:
+- Others:

--- a/.github/issue_commands.json
+++ b/.github/issue_commands.json
@@ -1,34 +1,34 @@
-[   
-    {
-      "type": "label",
-      "name": "datasource/TwinMaker",
-      "action": "addToProject",
-      "addToProject": {
-        "url": "https://github.com/orgs/grafana/projects/97"
-      }
-    },
-    {
-      "type": "label",
-      "name": "datasource/TwinMaker",
-      "action": "removeFromProject",
-      "removeFromProject": {
-        "url": "https://github.com/orgs/grafana/projects/97"
-      }
-    },
-    {
-      "type": "label",
-      "name": "type/docs",
-      "action": "addToProject",
-      "addToProject": {
-        "url": "https://github.com/orgs/grafana/projects/69"
-      }
-    },
-    {
-      "type": "label",
-      "name": "type/docs",
-      "action": "removeFromProject",
-      "removeFromProject": {
-        "url": "https://github.com/orgs/grafana/projects/69"
-      }
+[
+  {
+    "type": "label",
+    "name": "datasource/TwinMaker",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/97"
     }
+  },
+  {
+    "type": "label",
+    "name": "datasource/TwinMaker",
+    "action": "removeFromProject",
+    "removeFromProject": {
+      "url": "https://github.com/orgs/grafana/projects/97"
+    }
+  },
+  {
+    "type": "label",
+    "name": "type/docs",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/69"
+    }
+  },
+  {
+    "type": "label",
+    "name": "type/docs",
+    "action": "removeFromProject",
+    "removeFromProject": {
+      "url": "https://github.com/orgs/grafana/projects/69"
+    }
+  }
 ]

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -31,8 +31,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ env.AWS_DS_TOKEN_CREATOR_ID }}
-          private_key: ${{ env.AWS_DS_TOKEN_CREATOR_PEM }}
+          app-id: ${{ env.AWS_DS_TOKEN_CREATOR_ID }}
+          private-key: ${{ env.AWS_DS_TOKEN_CREATOR_PEM }}
       - name: Run Commands
         uses: ./actions/commands
         with:

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -2,13 +2,13 @@ name: Run commands when issues are labeled
 on:
   issues:
     types: [labeled, unlabeled]
-
-permissions:
-  contents: read
-  issues: write
-
+permissions: {}
 jobs:
   main:
+    permissions:
+      contents: read
+      id-token: write # The "id-token: write" permission is required by "get-vault-secrets" action
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
@@ -29,7 +29,7 @@ jobs:
             AWS_DS_TOKEN_CREATOR_PEM=aws-ds-token-creator:pem
       - name: 'Generate token'
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        uses: actions/create-github-app-token@v2
         with:
           app_id: ${{ env.AWS_DS_TOKEN_CREATOR_ID }}
           private_key: ${{ env.AWS_DS_TOKEN_CREATOR_PEM }}


### PR DESCRIPTION
View diff with hide whitespace changes

`.github/ISSUE_TEMPLATE/1-bug_report.md`
---
- Replace bitly links with unshortened links. When I clicked a bitly link, I got served a fullscreen ad that I had to exit to get to the actual linked community page.

`.github/issue_commands.json`
---
- Add `removeFromProject` actions to remove issues from our board when the labels are also removed

`.github/workflows/issue_commands.yml`
---
- Move permissions to job level instead
- Add's the `id-token: write` permission to the issue commands workflow which is required by the "get-vault-secrets" action
- Replaces the deprecated `tibdex/github-app-token` action with GitHub's `actions/create-github-app-token` for generating an app token