### PR TITLE
revert skip dev image for e2e tests

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,7 +42,6 @@ jobs:
       go-version: '1.24'
       golangci-lint-version: '2.1.6'
       github-draft-release: false # publish the github release directly, skipping the draft step
-      run-playwright-with-skip-grafana-dev-image: true
 
 
       # Scope for the plugin published to the catalog. Setting this to "grafana_cloud" will make it visible only in Grafana Cloud

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,4 +18,3 @@ jobs:
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       golangci-lint-version: '2.1.6'
-      run-playwright-with-skip-grafana-dev-image: true


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/114273 fixed the issue where dev images of grafana would error when starting if the `provisioning/dashboards` folder was missing. this reenables using the dev grafana images in the e2e tests.