### PR TITLE
docs: add warning banner for SceneViewer max version support

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -5,7 +5,7 @@
 Create end-user 3D digital twin applications to monitor industrial operations with AWS IoT TwinMaker. AWS IoT TwinMaker is a service that makes it faster and easier for developers to create digital replicas of real-world systems, helping more customers realize the potential of digital twins to optimize operations.
 
 {{< admonition type="warning" >}}
-The Grafana AWS IoT TwinMaker App will reach end-of-support in Grafana Cloud as of mid-April 2026. Users who require continued access can do so through any Grafana deployment version up to 13.1
+The Grafana AWS IoT TwinMaker App will no longer be available in Grafana Cloud as of mid-April 2026. Users who require continued access can use Grafana versions before 13.1
 {{< /admonition >}}
 
 The AWS IoT TwinMaker Application Grafana plugin provides custom panels, dashboard templates, and a datasource to connect to your digital twin data:

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -5,7 +5,7 @@
 Create end-user 3D digital twin applications to monitor industrial operations with AWS IoT TwinMaker. AWS IoT TwinMaker is a service that makes it faster and easier for developers to create digital replicas of real-world systems, helping more customers realize the potential of digital twins to optimize operations.
 
 {{< admonition type="warning" >}}
-The Grafana AWS IoT TwinMaker App will reach end-of-support in Grafana Cloud as of mid-April 2026. Users who require continued access can do so through a Grafana deployment they manage directly, on versions up to 13.0
+The Grafana AWS IoT TwinMaker App will reach end-of-support in Grafana Cloud as of mid-April 2026. Users who require continued access can do so through any Grafana deployment version up to 13.0
 {{< /admonition >}}
 
 The AWS IoT TwinMaker Application Grafana plugin provides custom panels, dashboard templates, and a datasource to connect to your digital twin data:

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -5,7 +5,7 @@
 Create end-user 3D digital twin applications to monitor industrial operations with AWS IoT TwinMaker. AWS IoT TwinMaker is a service that makes it faster and easier for developers to create digital replicas of real-world systems, helping more customers realize the potential of digital twins to optimize operations.
 
 {{< admonition type="warning" >}}
-The Grafana AWS IoT TwinMaker app will reach end of support on Grafana Cloud in mid-April 2026. Support will continue to be available on self-hosted Grafana for versions up to 13.0.
+The Grafana AWS IoT TwinMaker App will reach end-of-support in Grafana Cloud as of mid-April 2026. Users who require continued access can do so through a Grafana deployment they manage directly, on versions up to 13.0
 {{< /admonition >}}
 
 The AWS IoT TwinMaker Application Grafana plugin provides custom panels, dashboard templates, and a datasource to connect to your digital twin data:

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -4,6 +4,10 @@
 
 Create end-user 3D digital twin applications to monitor industrial operations with AWS IoT TwinMaker. AWS IoT TwinMaker is a service that makes it faster and easier for developers to create digital replicas of real-world systems, helping more customers realize the potential of digital twins to optimize operations.
 
+{{< admonition type="warning" >}}
+The Grafana AWS IoT TwinMaker app will reach end of support on Grafana Cloud in mid-April 2026. Continued support is available through self-hosted Grafana for compatible versions.
+{{< /admonition >}}
+
 The AWS IoT TwinMaker Application Grafana plugin provides custom panels, dashboard templates, and a datasource to connect to your digital twin data:
 
 - [Scene Viewer panel](#aws-iot-twinmaker-scene-viewer-panel)

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -5,7 +5,7 @@
 Create end-user 3D digital twin applications to monitor industrial operations with AWS IoT TwinMaker. AWS IoT TwinMaker is a service that makes it faster and easier for developers to create digital replicas of real-world systems, helping more customers realize the potential of digital twins to optimize operations.
 
 {{< admonition type="warning" >}}
-The Grafana AWS IoT TwinMaker app will reach end of support on Grafana Cloud in mid-April 2026. Continued support is available through self-hosted Grafana for compatible versions.
+The Grafana AWS IoT TwinMaker app will reach end of support on Grafana Cloud in mid-April 2026. Support will continue to be available on self-hosted Grafana for versions up to 13.0.
 {{< /admonition >}}
 
 The AWS IoT TwinMaker Application Grafana plugin provides custom panels, dashboard templates, and a datasource to connect to your digital twin data:

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -5,7 +5,7 @@
 Create end-user 3D digital twin applications to monitor industrial operations with AWS IoT TwinMaker. AWS IoT TwinMaker is a service that makes it faster and easier for developers to create digital replicas of real-world systems, helping more customers realize the potential of digital twins to optimize operations.
 
 {{< admonition type="warning" >}}
-The Grafana AWS IoT TwinMaker App will reach end-of-support in Grafana Cloud as of mid-April 2026. Users who require continued access can do so through any Grafana deployment version up to 13.0
+The Grafana AWS IoT TwinMaker App will reach end-of-support in Grafana Cloud as of mid-April 2026. Users who require continued access can do so through any Grafana deployment version up to 13.1
 {{< /admonition >}}
 
 The AWS IoT TwinMaker Application Grafana plugin provides custom panels, dashboard templates, and a datasource to connect to your digital twin data:

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -5,7 +5,7 @@
 Create end-user 3D digital twin applications to monitor industrial operations with AWS IoT TwinMaker. AWS IoT TwinMaker is a service that makes it faster and easier for developers to create digital replicas of real-world systems, helping more customers realize the potential of digital twins to optimize operations.
 
 {{< admonition type="warning" >}}
-The Grafana AWS IoT TwinMaker App will no longer be available in Grafana Cloud as of mid-April 2026. Users who require continued access can use Grafana versions before 13.1
+The SceneViewer panel in the TwinMaker App will be a breaking change in Grafana v13. It will continue to work as expected for all Grafana deployments before version 13.1.
 {{< /admonition >}}
 
 The AWS IoT TwinMaker Application Grafana plugin provides custom panels, dashboard templates, and a datasource to connect to your digital twin data:


### PR DESCRIPTION
Adds a warning admonition to the TwinMaker app docs indicating end of support on Grafana Cloud in mid-April 2026, with a note that self-hosted Grafana continues to support compatible versions.