### PR TITLE
Use GATB in GitHub workflows

### DIFF
--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -7,7 +7,7 @@ jobs:
   main:
     permissions:
       contents: read
-      id-token: write # The "id-token: write" permission is required by "get-vault-secrets" action
+      id-token: write # Required by create-github-app-token
       issues: write
     runs-on: ubuntu-latest
     steps:
@@ -20,21 +20,13 @@ jobs:
           persist-credentials: false
       - name: Install Actions
         run: npm install --production --prefix ./actions
-      - name: Get secrets from vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f2909d40e17c95ca36e7b643fa56ca53ca6571f9 # main
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          repo_secrets: |
-            AWS_DS_TOKEN_CREATOR_ID=aws-ds-token-creator:app_id
-            AWS_DS_TOKEN_CREATOR_PEM=aws-ds-token-creator:pem
-      - name: 'Generate token'
-        id: generate_token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-        with:
-          app-id: ${{ env.AWS_DS_TOKEN_CREATOR_ID }}
-          private-key: ${{ env.AWS_DS_TOKEN_CREATOR_PEM }}
+          github_app: aws-ds-token-creator
       - name: Run Commands
         uses: ./actions/commands
         with:
-          token: ${{ steps.generate_token.outputs.token }}
+          token: ${{ steps.get-github-app-token.outputs.token }}
           configPath: issue_commands


### PR DESCRIPTION
Updates this repo's GitHub workflows to use the GitHub App Token Broker for GitHub App token generation