### PR TITLE
Bumped ci-cd-workflows version to support new way to publish docs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ permissions: {}
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v10.1.0
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v10.1.0
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/README.md) or [src/README.md](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/README.md).
-->

**What this PR does / why we need it**:

Bumped ci-cd-workflows to version [10.1.0](https://github.com/grafana/plugin-ci-workflows/blob/main/.github/workflows/CHANGELOG.md#1010-2026-06-23) so doc publishing uses the PR approach instead of pushing directly to main

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:



